### PR TITLE
Maintain june 2022

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -226,7 +226,7 @@
     },
     {
       "projectID": 247401,
-      "fileID": 3366814,
+      "fileID": 3611193,
       "required": true
     },
     {
@@ -341,7 +341,7 @@
     },
     {
       "projectID": 255257,
-      "fileID": 3497720,
+      "fileID": 3507866,
       "required": true
     },
     {
@@ -371,7 +371,7 @@
     },
     {
       "projectID": 253043,
-      "fileID": 3064112,
+      "fileID": 3597087,
       "required": true
     },
     {
@@ -521,7 +521,7 @@
     },
     {
       "projectID": 239197,
-      "fileID": 3642364,
+      "fileID": 3784010,
       "required": true
     },
     {
@@ -631,12 +631,12 @@
     },
     {
       "projectID": 319441,
-      "fileID": 3536155,
+      "fileID": 3819917,
       "required": true
     },
     {
       "projectID": 293268,
-      "fileID": 3712956,
+      "fileID": 3832678,
       "required": true
     },
     {
@@ -646,7 +646,7 @@
     },
     {
       "projectID": 244258,
-      "fileID": 3268501,
+      "fileID": 3553627,
       "required": true
     },
     {
@@ -791,7 +791,7 @@
     },
     {
       "projectID": 236541,
-      "fileID": 3434864,
+      "fileID": 3801015,
       "required": true
     },
     {
@@ -821,12 +821,12 @@
     },
     {
       "projectID": 220954,
-      "fileID": 3368737,
+      "fileID": 3840577,
       "required": true
     },
     {
       "projectID": 238222,
-      "fileID": 3040523,
+      "fileID": 3043174,
       "required": true
     },
     {
@@ -1166,7 +1166,7 @@
     },
     {
       "projectID": 246183,
-      "fileID": 3484394,
+      "fileID": 3804097,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -341,7 +341,7 @@
     },
     {
       "projectID": 255257,
-      "fileID": 3507866,
+      "fileID": 3497720,
       "required": true
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -811,7 +811,7 @@
     },
     {
       "projectID": 605280,
-      "fileID": 3776780,
+      "fileID": 3847990,
       "required": true
     },
     {

--- a/overrides/config/enderio/recipes/user/user_recipes.xml
+++ b/overrides/config/enderio/recipes/user/user_recipes.xml
@@ -706,4 +706,26 @@
     <disabled />
   </recipe>
 
+  <recipe name="Soul Binder: Reanimation" required="true">
+    <soulbinding energy="100000" levels="4">
+      <input name="ZOMBIE_CONTROLLER" />
+      <soul name="minecraft:zombie" />
+      <soul name="minecraft:zombie_villager" />
+      <soul name="minecraft:husk" />
+      <soul name="abyssalcraft:abyssalzombie" />
+      <soul name="galacticraftcore:evolved_zombie" />
+      <soul name="thaumcraft:brainyzombie" />
+      <soul name="thaumcraft:giantbrainyzombie" />
+      <output name="FRANKEN_ZOMBIE" />
+    </soulbinding>
+  </recipe>
+
+  <recipe name="Soul Binder: Attractor Crystal" required="true">
+    <soulbinding energy="100000" levels="4">
+      <input name="item:enderio:item_material:18" />
+      <soul name="divinerpg:scorcher" />
+      <output name="ATTRACTOR_CRYSTAL" />
+    </soulbinding>
+  </recipe>
+
 </enderio:recipes>

--- a/overrides/config/enderio/recipes/user/user_recipes.xml
+++ b/overrides/config/enderio/recipes/user/user_recipes.xml
@@ -713,7 +713,6 @@
       <soul name="minecraft:zombie_villager" />
       <soul name="minecraft:husk" />
       <soul name="abyssalcraft:abyssalzombie" />
-      <soul name="galacticraftcore:evolved_zombie" />
       <soul name="thaumcraft:brainyzombie" />
       <soul name="thaumcraft:giantbrainyzombie" />
       <output name="FRANKEN_ZOMBIE" />

--- a/overrides/config/jei/itemBlacklist.cfg
+++ b/overrides/config/jei/itemBlacklist.cfg
@@ -523,6 +523,7 @@ advanced {
         appliedenergistics2:facade:{damage:11,item:"chisel:quartz"}
         appliedenergistics2:facade:{damage:6,item:"erebus:gneiss"}
         extracells:pattern.fluid:refined_oil;m=0
+        enderio:item_soul_vial:entity.entity_zombie_slave.name
         thermalexpansion:florb:starmetal
         enderio:item_soul_vial:Liopleurodon
         appliedenergistics2:facade:{damage:0,item:"erebus:wasp_nest"}
@@ -1832,6 +1833,7 @@ advanced {
         openblocks:tank:construction_alloy;
         appliedenergistics2:facade:{damage:2,item:"chisel:sandstonered2"}
         appliedenergistics2:facade:{damage:4,item:"erebus:capstone"}
+        twilightforest:boss_spawner
         appliedenergistics2:facade:{damage:3,item:"chisel:bookshelf_birch"}
         appliedenergistics2:facade:{damage:0,item:"ezstorage:hyper_storage_box"}
         enderio:block_not_unholy_dark_fused_glass:2
@@ -2847,6 +2849,7 @@ advanced {
         enderio:item_broken_spawner:Wildwood Cadillion
         appliedenergistics2:facade:{damage:3,item:"minecraft:monster_egg"}
         thermalexpansion:florb:manasteel
+        enderio:item_soul_vial:Clam
         appliedenergistics2:facade:{damage:6,item:"chisel:bookshelf_birch"}
         appliedenergistics2:facade:{damage:0,item:"chisel:glowstone2"}
         appliedenergistics2:facade:{damage:6,item:"chisel:voidstone"}
@@ -4202,6 +4205,7 @@ advanced {
         thermalexpansion:morb:thaumcraft:taintswarm
         tconstruct:cross_guard:0:gaia
         appliedenergistics2:facade:{damage:0,item:"divinerpg:apalachia_grass"}
+        enderio:item_broken_spawner:entity.entity_zombie_slave.name
         appliedenergistics2:facade:{damage:7,item:"chisel:sandstone-scribbles"}
         bewitchment:silver_axe
         modulardiversity:blockweatherdetector
@@ -5344,6 +5348,7 @@ advanced {
         enderio:item_broken_spawner:Zombie
         appliedenergistics2:facade:{damage:0,item:"roots:runed_oak"}
         roots:staff:spell_growth_infusion
+        enderio:item_soul_vial:entity.entity_husk_slave.name
         appliedenergistics2:facade:{damage:10,item:"chisel:arcane_stone1"}
         appliedenergistics2:facade:{damage:0,item:"chisel:emerald"}
         thermalexpansion:morb:tconstruct:blueslime
@@ -6251,6 +6256,7 @@ advanced {
         appliedenergistics2:facade:{damage:7,item:"chisel:bookshelf_birch"}
         appliedenergistics2:facade:{damage:5,item:"lightningcraft:stone_block"}
         extracells:pattern.fluid:cold_iron;m=0
+        enderio:item_broken_spawner:Clam
         appliedenergistics2:facade:{damage:5,item:"thermalfoundation:storage"}
         appliedenergistics2:facade:{damage:15,item:"mekanism:basicblock"}
         appliedenergistics2:facade:{damage:3,item:"undergroundbiomes:sedimentary_stone_thaumcraft_ore_amber"}
@@ -6269,6 +6275,7 @@ advanced {
         enderio:item_soul_vial:Husk
         appliedenergistics2:facade:{damage:2,item:"galacticraftplanets:venus"}
         appliedenergistics2:facade:{damage:6,item:"chisel:templemossy"}
+        enderio:item_broken_spawner:entity.entity_husk_slave.name
         enderio:item_broken_spawner:Zombie Ant Soldier
         appliedenergistics2:facade:{damage:4,item:"undergroundbiomes:metamorphic_overgrown_snowed"}
         appliedenergistics2:facade:{damage:0,item:"chisel:concrete_magenta"}
@@ -8264,6 +8271,7 @@ advanced {
         appliedenergistics2:facade:{damage:3,item:"natura:overworld_planks"}
         appliedenergistics2:facade:{damage:4,item:"undergroundbiomes:metamorphic_stone_actuallyadditions_block_misc_3"}
         divinerpg:bedrock_pickaxe
+        enderio:item_broken_spawner:Evoker
         appliedenergistics2:facade:{damage:3,item:"aether_legacy:dungeon_trap"}
         extracells:pattern.fluid:fierymetal;m=0
         extracells:pattern.fluid:fuel;m=0

--- a/overrides/config/jei/itemBlacklist.cfg
+++ b/overrides/config/jei/itemBlacklist.cfg
@@ -2421,6 +2421,7 @@ advanced {
         enderio:item_broken_spawner:Beetle Larva
         tconstruct:tough_binding:0:gaia
         appliedenergistics2:facade:{damage:2,item:"chisel:concrete_cyan1"}
+        botania:brewvial:warpWard
         appliedenergistics2:facade:{damage:3,item:"astralsorcery:blockblackmarble"}
         appliedenergistics2:facade:{damage:0,item:"erebus:grandmas_shoes_mushroom_block"}
         appliedenergistics2:facade:{damage:0,item:"chisel:sandstone-scribbles"}
@@ -4675,6 +4676,7 @@ advanced {
         thermalexpansion:florb:uranium
         appliedenergistics2:facade:{damage:0,item:"abyssalcraft:abycopore"}
         enderio:item_broken_spawner:Enchanted Warrior
+        botania:incensestick:warpWard
         thermalexpansion:florb:impure_mercury_iodine_mixture
         bigreactors:mineralbenitoite
         appliedenergistics2:facade:{damage:8,item:"chisel:prismarine1"}
@@ -8616,6 +8618,7 @@ advanced {
         appliedenergistics2:facade:{damage:8,item:"chisel:paper"}
         appliedenergistics2:facade:{damage:4,item:"botania:altgrass"}
         appliedenergistics2:facade:{damage:0,item:"bewitchment:nethersteel"}
+        botania:brewflask:warpWard
         enderio:item_broken_spawner:Crypt Keeper
         immersiveengineering:metal:18
         immersiveengineering:metal:19

--- a/overrides/config/undergroundbiomes.cfg
+++ b/overrides/config/undergroundbiomes.cfg
@@ -195,6 +195,9 @@ visual {
 
     # Replace sandstone with UBC variants.
     B:ReplaceSandstone=true
+    B:ReplaceStoneBrick=true
+    B:ReplaceStoneSlab=true
+    B:ReplaceStoneWall=true
 
     # Use UB stones in villages structures
     B:UBifyVillages=true

--- a/overrides/scripts/AppliedEnergistics2.zs
+++ b/overrides/scripts/AppliedEnergistics2.zs
@@ -353,11 +353,11 @@ recipes.addShaped(<appliedenergistics2:material:32>, [[<alchemistry:ingot:3>,<ap
 
 # 16^3 Spatial Component
 recipes.remove(<appliedenergistics2:material:33>);
-recipes.addShaped(<appliedenergistics2:material:33>, [[<alchemistry:ingot:3>,<appliedenergistics2:material:32>,<alchemistry:ingot:3>],[<appliedenergistics2:material:32>,<contenttweaker:clearance_processor>,<appliedenergistics2:material:32>],[<alchemistry:ingot:3>,<appliedenergistics2:material:32>,<alchemistry:ingot:3>]]);
+recipes.addShaped(<appliedenergistics2:material:33>, [[<alchemistry:ingot:3>,<appliedenergistics2:material:32>,<alchemistry:ingot:3>],[<appliedenergistics2:material:32>,<contenttweaker:methodology_processor>,<appliedenergistics2:material:32>],[<alchemistry:ingot:3>,<appliedenergistics2:material:32>,<alchemistry:ingot:3>]]);
 
 # 128^3 Spatial Component
 recipes.remove(<appliedenergistics2:material:34>);
-recipes.addShaped(<appliedenergistics2:material:34>, [[<alchemistry:ingot:3>,<appliedenergistics2:material:33>,<alchemistry:ingot:3>],[<appliedenergistics2:material:33>,<contenttweaker:scheduling_processor>,<appliedenergistics2:material:33>],[<alchemistry:ingot:3>,<appliedenergistics2:material:33>,<alchemistry:ingot:3>]]);
+recipes.addShaped(<appliedenergistics2:material:34>, [[<alchemistry:ingot:3>,<appliedenergistics2:material:33>,<alchemistry:ingot:3>],[<appliedenergistics2:material:33>,<contenttweaker:methodology_processor>,<appliedenergistics2:material:33>],[<alchemistry:ingot:3>,<appliedenergistics2:material:33>,<alchemistry:ingot:3>]]);
 
 # Spatial IO Port
 recipes.remove(<appliedenergistics2:spatial_io_port>);
@@ -410,24 +410,24 @@ recipes.addShaped(<appliedenergistics2:part:76>, [[<appliedenergistics2:part:56>
 
 # Creative Energy Cell
 mods.extendedcrafting.TableCrafting.addShaped(<appliedenergistics2:creative_energy_cell>,
-[[<extendedcrafting:storage>, <extendedcrafting:storage>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <extendedcrafting:storage>, <extendedcrafting:storage>], 
-[<extendedcrafting:storage>, <extendedcrafting:storage>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <extendedcrafting:storage>, <extendedcrafting:storage>], 
-[<contenttweaker:white_matter>, <appliedenergistics2:dense_energy_cell>, <appliedenergistics2:dense_energy_cell>, <solarflux:solar_panel_chaotic>, <appliedenergistics2:dense_energy_cell>, <appliedenergistics2:dense_energy_cell>, <contenttweaker:white_matter>], 
-[<contenttweaker:white_matter>, <appliedenergistics2:dense_energy_cell>, <draconicevolution:draconium_capacitor:2>, <projecte:item.pe_klein_star:5>, <thermalexpansion:capacitor:32000>.withTag({Energy: 25000000}), <appliedenergistics2:dense_energy_cell>, <contenttweaker:white_matter>], 
-[<contenttweaker:white_matter>, <appliedenergistics2:dense_energy_cell>, <appliedenergistics2:dense_energy_cell>, <enderio:block_cap_bank>, <appliedenergistics2:dense_energy_cell>, <appliedenergistics2:dense_energy_cell>, <contenttweaker:white_matter>], 
-[<extendedcrafting:storage>, <extendedcrafting:storage>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <extendedcrafting:storage>, <extendedcrafting:storage>], 
+[[<extendedcrafting:storage>, <extendedcrafting:storage>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <extendedcrafting:storage>, <extendedcrafting:storage>],
+[<extendedcrafting:storage>, <extendedcrafting:storage>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <extendedcrafting:storage>, <extendedcrafting:storage>],
+[<contenttweaker:white_matter>, <appliedenergistics2:dense_energy_cell>, <appliedenergistics2:dense_energy_cell>, <solarflux:solar_panel_chaotic>, <appliedenergistics2:dense_energy_cell>, <appliedenergistics2:dense_energy_cell>, <contenttweaker:white_matter>],
+[<contenttweaker:white_matter>, <appliedenergistics2:dense_energy_cell>, <draconicevolution:draconium_capacitor:2>, <projecte:item.pe_klein_star:5>, <thermalexpansion:capacitor:32000>.withTag({Energy: 25000000}), <appliedenergistics2:dense_energy_cell>, <contenttweaker:white_matter>],
+[<contenttweaker:white_matter>, <appliedenergistics2:dense_energy_cell>, <appliedenergistics2:dense_energy_cell>, <enderio:block_cap_bank>, <appliedenergistics2:dense_energy_cell>, <appliedenergistics2:dense_energy_cell>, <contenttweaker:white_matter>],
+[<extendedcrafting:storage>, <extendedcrafting:storage>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <extendedcrafting:storage>, <extendedcrafting:storage>],
 [<extendedcrafting:storage>, <extendedcrafting:storage>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <contenttweaker:white_matter>, <extendedcrafting:storage>, <extendedcrafting:storage>]]);
 
 # Creative ME Storage Cell
 mods.extendedcrafting.TableCrafting.addShaped(<appliedenergistics2:creative_storage_cell>.withTag({}),
-[[<alchemistry:ingot:69>, <alchemistry:ingot:69>, <alchemistry:ingot:69>, <alchemistry:ingot:58>, <alchemistry:ingot:58>, <alchemistry:ingot:58>, <alchemistry:ingot:69>, <alchemistry:ingot:69>, <alchemistry:ingot:69>], 
-[<alchemistry:ingot:69>, <botania:pool:1>, <contenttweaker:essence_of_space>, <appliedenergistics2:creative_energy_cell>, <extracells:storage.component:10>, <appliedenergistics2:creative_energy_cell>, <contenttweaker:essence_of_space>, <botania:pool:1>, <alchemistry:ingot:69>], 
-[<alchemistry:ingot:69>, <contenttweaker:essence_of_space>, <extracells:storage.component:3>, <extracells:storage.component:3>, <extracells:storage.component:17>, <extracells:storage.component:3>, <extracells:storage.component:3>, <contenttweaker:essence_of_space>, <alchemistry:ingot:69>], 
-[<alchemistry:ingot:58>, <appliedenergistics2:creative_energy_cell>, <extracells:storage.component:3>, <thaumicenergistics:essentia_component_64k>, <thaumicenergistics:essentia_component_64k>, <thaumicenergistics:essentia_component_64k>, <extracells:storage.component:3>, <appliedenergistics2:creative_energy_cell>, <alchemistry:ingot:58>], 
-[<alchemistry:ingot:58>, <extracells:storage.component:10>, <extracells:storage.component:17>, <thaumicenergistics:essentia_component_64k>, <erebus:wand_of_animation>, <thaumicenergistics:essentia_component_64k>, <extracells:storage.component:17>, <extracells:storage.component:10>, <alchemistry:ingot:58>], 
-[<alchemistry:ingot:58>, <appliedenergistics2:creative_energy_cell>, <extracells:storage.component:3>, <thaumicenergistics:essentia_component_64k>, <thaumicenergistics:essentia_component_64k>, <thaumicenergistics:essentia_component_64k>, <extracells:storage.component:3>, <appliedenergistics2:creative_energy_cell>, <alchemistry:ingot:58>], 
-[<alchemistry:ingot:69>, <contenttweaker:essence_of_space>, <extracells:storage.component:3>, <extracells:storage.component:3>, <extracells:storage.component:17>, <extracells:storage.component:3>, <extracells:storage.component:3>, <contenttweaker:essence_of_space>, <alchemistry:ingot:69>], 
-[<alchemistry:ingot:69>, <botania:pool:1>, <contenttweaker:essence_of_space>, <appliedenergistics2:creative_energy_cell>, <extracells:storage.component:10>, <appliedenergistics2:creative_energy_cell>, <contenttweaker:essence_of_space>, <botania:pool:1>, <alchemistry:ingot:69>], 
+[[<alchemistry:ingot:69>, <alchemistry:ingot:69>, <alchemistry:ingot:69>, <alchemistry:ingot:58>, <alchemistry:ingot:58>, <alchemistry:ingot:58>, <alchemistry:ingot:69>, <alchemistry:ingot:69>, <alchemistry:ingot:69>],
+[<alchemistry:ingot:69>, <botania:pool:1>, <contenttweaker:essence_of_space>, <appliedenergistics2:creative_energy_cell>, <extracells:storage.component:10>, <appliedenergistics2:creative_energy_cell>, <contenttweaker:essence_of_space>, <botania:pool:1>, <alchemistry:ingot:69>],
+[<alchemistry:ingot:69>, <contenttweaker:essence_of_space>, <extracells:storage.component:3>, <extracells:storage.component:3>, <extracells:storage.component:17>, <extracells:storage.component:3>, <extracells:storage.component:3>, <contenttweaker:essence_of_space>, <alchemistry:ingot:69>],
+[<alchemistry:ingot:58>, <appliedenergistics2:creative_energy_cell>, <extracells:storage.component:3>, <thaumicenergistics:essentia_component_64k>, <thaumicenergistics:essentia_component_64k>, <thaumicenergistics:essentia_component_64k>, <extracells:storage.component:3>, <appliedenergistics2:creative_energy_cell>, <alchemistry:ingot:58>],
+[<alchemistry:ingot:58>, <extracells:storage.component:10>, <extracells:storage.component:17>, <thaumicenergistics:essentia_component_64k>, <erebus:wand_of_animation>, <thaumicenergistics:essentia_component_64k>, <extracells:storage.component:17>, <extracells:storage.component:10>, <alchemistry:ingot:58>],
+[<alchemistry:ingot:58>, <appliedenergistics2:creative_energy_cell>, <extracells:storage.component:3>, <thaumicenergistics:essentia_component_64k>, <thaumicenergistics:essentia_component_64k>, <thaumicenergistics:essentia_component_64k>, <extracells:storage.component:3>, <appliedenergistics2:creative_energy_cell>, <alchemistry:ingot:58>],
+[<alchemistry:ingot:69>, <contenttweaker:essence_of_space>, <extracells:storage.component:3>, <extracells:storage.component:3>, <extracells:storage.component:17>, <extracells:storage.component:3>, <extracells:storage.component:3>, <contenttweaker:essence_of_space>, <alchemistry:ingot:69>],
+[<alchemistry:ingot:69>, <botania:pool:1>, <contenttweaker:essence_of_space>, <appliedenergistics2:creative_energy_cell>, <extracells:storage.component:10>, <appliedenergistics2:creative_energy_cell>, <contenttweaker:essence_of_space>, <botania:pool:1>, <alchemistry:ingot:69>],
 [<alchemistry:ingot:69>, <alchemistry:ingot:69>, <alchemistry:ingot:69>, <alchemistry:ingot:58>, <alchemistry:ingot:58>, <alchemistry:ingot:58>, <alchemistry:ingot:69>, <alchemistry:ingot:69>, <alchemistry:ingot:69>]]);
 
 # Pattern Expansion Card

--- a/overrides/scripts/BloodMagic.zs
+++ b/overrides/scripts/BloodMagic.zs
@@ -9,7 +9,7 @@ import mods.enderio.AlloySmelter as EIOAlloySmelter;
 import crafttweaker.item.IItemStack;
 import crafttweaker.item.IIngredient;
 import mods.botania.Apothecary;
-import mods.dj2addons.bloodmagic.HellfireForge as DJ2AddonsHellFireForge;
+import dj2addons.bloodmagic.HellfireForge as DJ2AddonsHellFireForge;
 
 print("STARTING BloodMagic.zs");
 

--- a/overrides/scripts/BloodMagic.zs
+++ b/overrides/scripts/BloodMagic.zs
@@ -220,7 +220,7 @@ blood_magic_add_rune_recipe(<bloodmagic:blood_rune:6>, <enderio:block_tank:1>, <
 
 # Incense Altar
 recipes.remove(<bloodmagic:incense_altar>);
-recipes.addShaped(<bloodmagic:incense_altar>, [[<enderutilities:enderpart:1>,null,<enderutilities:enderpart:1>],[<bloodmagic:blood_rune:4>,blood_orb_at_least_tier_1.reuse(),<bloodmagic:blood_rune:4>],[empowered_glod_crystal_block,<betternether:cincinnasite_forge>,empowered_glod_crystal_block]]);
+recipes.addShaped(<bloodmagic:incense_altar>, [[<enderutilities:enderpart:1>,null,<enderutilities:enderpart:1>],[<bloodmagic:blood_rune:4>,<contenttweaker:hardened_blood_droplet>,<bloodmagic:blood_rune:4>],[empowered_glod_crystal_block,<betternether:cincinnasite_forge>,empowered_glod_crystal_block]]);
 
 # Wooden Path
 recipes.remove(<bloodmagic:path>);

--- a/overrides/scripts/BloodMagic.zs
+++ b/overrides/scripts/BloodMagic.zs
@@ -224,7 +224,7 @@ recipes.addShaped(<bloodmagic:incense_altar>, [[<enderutilities:enderpart:1>,nul
 
 # Wooden Path
 recipes.remove(<bloodmagic:path>);
-mods.bloodmagic.AlchemyTable.addRecipe(<bloodmagic:path>, [<immersiveengineering:treated_wood>, <extrautils2:decorativesolidwood:1>, <evilcraft:undead_log>, <roots:wildwood_log>, <totemic:cedar_log>, <openblocks:path>], 25, 10, 1);
+mods.bloodmagic.AlchemyTable.addRecipe(<bloodmagic:path>, [<immersiveengineering:treated_wood>, <extrautils2:decorativesolidwood:1>, <evilcraft:undead_plank>, <roots:wildwood_planks>, <totemic:cedar_plank>, <openblocks:path>], 25, 10, 1);
 
 # Stone Brick Path
 recipes.remove(<bloodmagic:path:2>);

--- a/overrides/scripts/BloodMagic.zs
+++ b/overrides/scripts/BloodMagic.zs
@@ -220,19 +220,23 @@ blood_magic_add_rune_recipe(<bloodmagic:blood_rune:6>, <enderio:block_tank:1>, <
 
 # Incense Altar
 recipes.remove(<bloodmagic:incense_altar>);
-recipes.addShaped(<bloodmagic:incense_altar>, [[<enderutilities:enderpart:1>,null,<enderutilities:enderpart:1>],[<contenttweaker:holy_core>,<evilcraft:promise_acceptor:1>,<contenttweaker:holy_core>],[empowered_glod_crystal_block,<betternether:cincinnasite_forge>,empowered_glod_crystal_block]]);
+recipes.addShaped(<bloodmagic:incense_altar>, [[<enderutilities:enderpart:1>,null,<enderutilities:enderpart:1>],[<bloodmagic:blood_rune:4>,blood_orb_at_least_tier_1.reuse(),<bloodmagic:blood_rune:4>],[empowered_glod_crystal_block,<betternether:cincinnasite_forge>,empowered_glod_crystal_block]]);
 
 # Wooden Path
 recipes.remove(<bloodmagic:path>);
-recipes.addShaped(<bloodmagic:path>, [[<evilcraft:undead_plank>,<evilcraft:undead_plank>,<evilcraft:undead_plank>],[<evilcraft:undead_plank>,blood_orb_at_least_tier_2.reuse(),<evilcraft:undead_plank>],[<evilcraft:undead_plank>,<evilcraft:undead_plank>,<evilcraft:undead_plank>]]);
+mods.bloodmagic.AlchemyTable.addRecipe(<bloodmagic:path>, [<immersiveengineering:treated_wood>, <extrautils2:decorativesolidwood:1>, <evilcraft:undead_log>, <roots:wildwood_log>, <totemic:cedar_log>, <openblocks:path>], 25, 10, 1);
 
 # Stone Brick Path
 recipes.remove(<bloodmagic:path:2>);
-recipes.addShaped(<bloodmagic:path:2> * 2, [[<extrautils2:compressedcobblestone:1>,<bloodmagic:path>,<extrautils2:compressedcobblestone:1>],[<bloodmagic:path>,blood_orb_at_least_tier_3.reuse(),<bloodmagic:path>],[<extrautils2:compressedcobblestone:1>,<bloodmagic:path>,<extrautils2:compressedcobblestone:1>]]);
+mods.bloodmagic.AlchemyTable.addRecipe(<bloodmagic:path:2>, [<bloodmagic:path>, <bloodmagic:path>, <extrautils2:compressedcobblestone:1>, <extrautils2:compressedcobblestone:1>, <roots:runestone>, <roots:runestone>], 100, 10, 2);
 
 # Worn Stone Brick Path
 recipes.remove(<bloodmagic:path:4>);
-recipes.addShaped(<bloodmagic:path:4> * 2, [[<extrautils2:compressedcobblestone:2>,<bloodmagic:path:2>,<extrautils2:compressedcobblestone:2>],[<bloodmagic:path:2>,blood_orb_at_least_tier_4.reuse(),<bloodmagic:path:2>],[<extrautils2:compressedcobblestone:2>,<bloodmagic:path:2>,<extrautils2:compressedcobblestone:2>]]);
+mods.bloodmagic.AlchemyTable.addRecipe(<bloodmagic:path:4>, [<bloodmagic:path:2>, <bloodmagic:path:2>, <extrautils2:compressedcobblestone:2>, <extrautils2:compressedcobblestone:2>, <appliedenergistics2:material:45>, <appliedenergistics2:material:45>], 400, 10, 3);
+
+# Obsidian Brick Path
+recipes.remove(<bloodmagic:path:6>);
+mods.bloodmagic.AlchemyTable.addRecipe(<bloodmagic:path:6>, [<bloodmagic:path:4>, <bloodmagic:path:4>, <roots:runed_obsidian>, <roots:runed_obsidian>, <mekanism:basicblock:2>, <mekanism:basicblock:2>], 1600, 10, 3);
 
 # Binding Reagent
 mods.bloodmagic.TartaricForge.removeRecipe([<minecraft:glowstone_dust>,<minecraft:redstone>,<minecraft:gold_nugget>,<minecraft:gunpowder>]);
@@ -517,10 +521,6 @@ recipes.removeShapeless(<bloodmagic:ritual_stone>, [<bloodmagic:ritual_stone:6>]
 
 # Crystal Cluster
 recipes.addShaped(<bloodmagic:decorative_brick:2>, [[<bloodmagic:blood_shard:1>,<contenttweaker:magical_tablet>,<bloodmagic:blood_shard:1>],[<contenttweaker:magical_tablet>,<contenttweaker:angelic_silicon_crystal_block>,<contenttweaker:magical_tablet>],[<bloodmagic:blood_shard:1>,<contenttweaker:magical_tablet>,<bloodmagic:blood_shard:1>]]);
-
-# Obsidian Brick Path
-recipes.remove(<bloodmagic:path:6>);
-recipes.addShaped(<bloodmagic:path:6> * 2, [[<botania:quartz>,<bloodmagic:path:4>,<botania:quartz>],[<bloodmagic:path:4>,blood_orb_at_least_tier_5.reuse(),<bloodmagic:path:4>],[<botania:quartz>,<bloodmagic:path:4>,<botania:quartz>]]);
 
 # Weak Blood Shard tooltip
 <bloodmagic:blood_shard>.addTooltip(format.white("Slay mobs with your activated ") + format.red("Bound Blade"));

--- a/overrides/scripts/Botania.zs
+++ b/overrides/scripts/Botania.zs
@@ -1,4 +1,4 @@
-# Author: Atricos
+# Author: Atricos, WaitingIdly
 
 import crafttweaker.item.IItemStack;
 import crafttweaker.item.IIngredient;
@@ -15,6 +15,8 @@ import mods.botania.RuneAltar;
 import mods.botania.ElvenTrade;
 import mods.bloodmagic.AlchemyTable;
 import mods.botania.Orechid;
+import dj2addons.botania.Brews;
+import dj2addons.botania.Brew;
 
 print("STARTING Botania.zs");
 
@@ -907,7 +909,7 @@ recipes.addShaped(<botania:cellblock> * 4, [[<mysticalagriculture:nature_essence
 
 # Botanical Brewery
 recipes.remove(<botania:brewery>);
-recipes.addShaped(<botania:brewery>, [[<contenttweaker:purified_tablet>,null,<contenttweaker:purified_tablet>],[<botania:livingrock>,<contenttweaker:rune_of_mana>,<botania:livingrock>],[<botania:livingrock>,<botania:storage:4>,<botania:livingrock>]]);
+recipes.addShaped(<botania:brewery>, [[<contenttweaker:purified_tablet>,null,<contenttweaker:purified_tablet>],[<botania:livingrock>,<contenttweaker:rune_of_mana>,<botania:livingrock>],[<botania:livingrock>,<botania:alchemycatalyst>,<botania:livingrock>]]);
 
 # Tainted Blood Pendant
 recipes.remove(<botania:bloodpendant>);
@@ -920,6 +922,31 @@ recipes.addShapedMirrored(<botania:incensestick>.withTag({}), [[null,null,<botan
 # Incense Plate
 recipes.remove(<botania:incenseplate>);
 recipes.addShaped(<botania:incenseplate>, [[null,<botania:manaresource:5>,null],[<botania:livingwood>,<minecraft:beacon>,<botania:livingwood>]]);
+
+# Saturation Brew
+Brews.addBrewRecipe(
+    Brews.makeBrew(
+        "dj2addons.saturegen",
+        "dj2addons.brew.saturegen",
+        100000,
+        16262179,
+        <potion:dj2addons:saturegen>.makePotionEffect(12000, 1)
+    ),
+    [<minecraft:nether_wart>, <totemic:cooked_buffalo_meat>, <contenttweaker:chicken_nugget>, <contenttweaker:burger>, <contenttweaker:taco>]
+);
+
+# Warp Ward Brew
+mods.botania.Brew.removeRecipe("warpWard");
+Brews.addBrewRecipe(
+    Brews.makeBrew(
+        "thaumcraft:warpward",
+        "Sane Thoughts",
+        100000,
+        16503291,
+        <potion:thaumcraft:warpward>.makePotionEffect(12000, 0)
+    ),
+    [<minecraft:nether_wart>, <thaumcraft:salis_mundus>, <thaumcraft:bath_salts>, <thaumcraft:sanity_soap>, <contenttweaker:conducted_impetus>, <thaumcraft:sanity_checker>]
+);
 
 # Corporea Spark
 recipes.remove(<botania:corporeaspark>);

--- a/overrides/scripts/ContentTweakerBlocks.zs
+++ b/overrides/scripts/ContentTweakerBlocks.zs
@@ -250,6 +250,11 @@ glod_crystal_block.setBlockResistance(6);
 glod_crystal_block.setToolClass("pickaxe");
 glod_crystal_block.setToolLevel(2);
 glod_crystal_block.setBlockSoundType(<soundtype:metal>);
+glod_crystal_block.setDropHandler(function(drops, world, position, state, fortune) {
+	drops.clear();
+	drops.add(<item:contenttweaker:glod_crystal_block>.withTag({display: {Name: "§6Glod Crystal Block"}}));
+	return;
+});
 glod_crystal_block.register();
 
 var empowered_glod_crystal_block = VanillaFactory.createBlock("empowered_glod_crystal_block", <blockmaterial:iron>);
@@ -258,6 +263,11 @@ empowered_glod_crystal_block.setBlockResistance(6);
 empowered_glod_crystal_block.setToolClass("pickaxe");
 empowered_glod_crystal_block.setToolLevel(2);
 empowered_glod_crystal_block.setBlockSoundType(<soundtype:metal>);
+empowered_glod_crystal_block.setDropHandler(function(drops, world, position, state, fortune) {
+	drops.clear();
+	drops.add(<item:contenttweaker:empowered_glod_crystal_block>.withTag({display: {Name: "§6Empowered Glod Crystal Block"}}));
+	return;
+});
 empowered_glod_crystal_block.register();
 
 var block_of_elevation = VanillaFactory.createBlock("block_of_elevation", <blockmaterial:iron>);
@@ -414,7 +424,7 @@ electrotine_ore.setToolLevel(1);
 electrotine_ore.setBlockSoundType(<soundtype:stone>);
 electrotine_ore.register();
 electrotine_ore.setDropHandler(function(drops, world, position, state, fortune) {
-	
+
 	drops.clear();
 	drops.add(<item:contenttweaker:electrotine> * 2);
 	drops.add(<item:contenttweaker:electrotine> % 50);
@@ -422,7 +432,7 @@ electrotine_ore.setDropHandler(function(drops, world, position, state, fortune) 
 	if(fortune > 0) {
 		drops.add(<item:contenttweaker:electrotine> * fortune);
 	}
-	
+
 	return;
 });
 

--- a/overrides/scripts/ContentTweakerRecipes.zs
+++ b/overrides/scripts/ContentTweakerRecipes.zs
@@ -2071,12 +2071,13 @@ mods.extendedcrafting.CompressionCrafting.addRecipe(<contenttweaker:creative_mes
 mods.extendedcrafting.CompressionCrafting.addRecipe(<contenttweaker:creative_singularity>, <contenttweaker:creative_mesh>, 100000000, <contenttweaker:singularification_catalyst>, 100000000);
 
 # Unwarpification Talisman
-mods.extendedcrafting.TableCrafting.addShaped(<contenttweaker:unwarpification_talisman>,
-[[<extendedcrafting:singularity_custom:158>, <thaumcraft:sanity_checker>, <projecte:item.pe_covalence_dust:2>, <thaumcraft:sanity_checker>, <extendedcrafting:singularity_custom:158>],
-[<thaumcraft:sanity_checker>, <botania:blackholetalisman>, <alchemistry:ingot:96>, <botania:blackholetalisman>, <thaumcraft:sanity_checker>],
-[<projecte:item.pe_covalence_dust:2>, <alchemistry:ingot:96>, <bloodmagic:decorative_brick:2>, <alchemistry:ingot:96>, <projecte:item.pe_covalence_dust:2>],
-[<thaumcraft:sanity_checker>, <botania:blackholetalisman>, <alchemistry:ingot:96>, <botania:blackholetalisman>, <thaumcraft:sanity_checker>],
-[<extendedcrafting:singularity_custom:158>, <thaumcraft:sanity_checker>, <projecte:item.pe_covalence_dust:2>, <thaumcraft:sanity_checker>, <extendedcrafting:singularity_custom:158>]]);
+mods.astralsorcery.Altar.addConstellationAltarRecipe("dj2:shaped/internal/altar/unwarpification_talisman", <contenttweaker:unwarpification_talisman>, 500, 100,
+[<botania:bloodpendant>.withTag({brewKey: "thaumcraft:warpward"}),<botania:blackholetalisman>,<botania:bloodpendant>.withTag({brewKey: "thaumcraft:warpward"}),
+<botania:blackholetalisman>,<thaumcraft:sanity_checker>,<botania:blackholetalisman>,
+<botania:bloodpendant>.withTag({brewKey: "thaumcraft:warpward"}),<botania:blackholetalisman>,<botania:bloodpendant>.withTag({brewKey: "thaumcraft:warpward"}),
+<botania:brewflask>.withTag({brewKey: "thaumcraft:warpward"}),<botania:brewflask>.withTag({brewKey: "thaumcraft:warpward"}),<botania:brewflask>.withTag({brewKey: "thaumcraft:warpward"}),<botania:brewflask>.withTag({brewKey: "thaumcraft:warpward"}),
+<thaumicaugmentation:material:5>,<thaumicaugmentation:material:5>,<thaumicaugmentation:material:5>,<thaumicaugmentation:material:5>,<thaumicaugmentation:material:5>,<thaumicaugmentation:material:5>,<thaumicaugmentation:material:5>,<thaumicaugmentation:material:5>
+]);
 <contenttweaker:unwarpification_talisman>.addTooltip(format.white("Right Click to set your Thaumcraft Warp level to 0!"));
 
 # Goddess' Pearl

--- a/overrides/scripts/ContentTweakerRecipes.zs
+++ b/overrides/scripts/ContentTweakerRecipes.zs
@@ -399,7 +399,7 @@ recipes.addShaped(<contenttweaker:golder_molder_folder>, [[<aether_legacy:ice_ri
 <contenttweaker:golder_molder_folder>.addTooltip(format.white(format.italic("Has 16 uses!")));
 
 # Enchanted Golden Berry
-recipes.addShaped(<contenttweaker:enchanted_golden_berry>, [[<minecraft:gold_ingot>,<aether_legacy:enchanted_blueberry>,<minecraft:gold_ingot>],[<aether_legacy:golden_amber>,<contenttweaker:golder_molder_folder>.anyDamage().transformDamage(1),<aether_legacy:golden_amber>],[<minecraft:gold_ingot>,<aether_legacy:enchanted_gravitite>,<minecraft:gold_ingot>]]);
+recipes.addShaped(<contenttweaker:enchanted_golden_berry> * 4, [[<aether_legacy:enchanted_blueberry>,<aether_legacy:enchanted_gravitite>,<aether_legacy:enchanted_blueberry>],[<aether_legacy:golden_amber>,<contenttweaker:golder_molder_folder>.anyDamage().transformDamage(1),<aether_legacy:golden_amber>],[<aether_legacy:enchanted_blueberry>,<aether_legacy:enchanted_gravitite>,<aether_legacy:enchanted_blueberry>]]);
 
 # Enchanted Golden Berry Stem
 recipes.addShaped(<contenttweaker:enchanted_golden_berry_stem>, [[<contenttweaker:enchanted_golden_berry>,<lightningcraft:rod:2>,<contenttweaker:enchanted_golden_berry>],[null,<lightningcraft:rod:2>,null],[<contenttweaker:enchanted_golden_berry>,<lightningcraft:rod:2>,<contenttweaker:enchanted_golden_berry>]]);

--- a/overrides/scripts/DankNull.zs
+++ b/overrides/scripts/DankNull.zs
@@ -4,24 +4,28 @@ import crafttweaker.item.IItemStack;
 
 print("STARTING DankNull.zs");
 
-function removeDarkNullEasyRecipe(output as IItemStack, input_panel as IItemStack) {
+function removeDankNullEasyRecipe(output as IItemStack, input_panel as IItemStack) {
 	recipes.removeShaped(output, [[null,input_panel,null],[input_panel,input_panel,input_panel],[null,input_panel,null]]);
 }
 
+# /dank/null/MK I
+recipes.remove(<danknull:dank_null_0>);
+recipes.addShaped(<danknull:dank_null_0>.withTag({ench: [{lvl: 10 as short, id: 67 as short}]}), [[null, <danknull:dank_null_panel_0>, null], [<danknull:dank_null_panel_0>, <danknull:dank_null_panel_0>, <danknull:dank_null_panel_0>], [null, <danknull:dank_null_panel_0>, null]]);
+
 # /dank/null/MK II
-removeDarkNullEasyRecipe(<danknull:dank_null_1>, <danknull:dank_null_panel_1>);
+removeDankNullEasyRecipe(<danknull:dank_null_1>, <danknull:dank_null_panel_1>);
 
 # /dank/null/MK III
-removeDarkNullEasyRecipe(<danknull:dank_null_2>, <danknull:dank_null_panel_2>);
+removeDankNullEasyRecipe(<danknull:dank_null_2>, <danknull:dank_null_panel_2>);
 
 # /dank/null/MK IV
-removeDarkNullEasyRecipe(<danknull:dank_null_3>, <danknull:dank_null_panel_3>);
+removeDankNullEasyRecipe(<danknull:dank_null_3>, <danknull:dank_null_panel_3>);
 
 # /dank/null/MK V
-removeDarkNullEasyRecipe(<danknull:dank_null_4>, <danknull:dank_null_panel_4>);
+removeDankNullEasyRecipe(<danknull:dank_null_4>, <danknull:dank_null_panel_4>);
 
 # /dank/null/MK VI
-removeDarkNullEasyRecipe(<danknull:dank_null_5>, <danknull:dank_null_panel_5>);
+removeDankNullEasyRecipe(<danknull:dank_null_5>, <danknull:dank_null_panel_5>);
 
 # RedStone /dank/null Panel
 recipes.remove(<danknull:dank_null_panel_0>);

--- a/overrides/scripts/DivineRPGVetheaRecipes.zs
+++ b/overrides/scripts/DivineRPGVetheaRecipes.zs
@@ -115,6 +115,9 @@ recipes.addShapeless(<minecraft:melon>, [<divinerpg:dream_melon>]);
 
 # Eye of the Nightmare recipe is in ContentTweakerRecipes.zs
 
+# Warp Ward Vial
+recipes.addShapeless(<botania:brewvial>.withTag({brewKey: "thaumcraft:warpward"}), [<divinerpg:firelight>, <divinerpg:fire_crystal>, <mekanism:salt>, <minecraft:glass_bottle>]);
+
 # Ender Chest (EnderStorage)
 recipes.addShaped(<enderstorage:ender_storage>, [[<botania:blazeblock>,<divinerpg:heliosis_lump>,<botania:blazeblock>],[<contenttweaker:eye_of_the_nightmare>,<mekanism:basicblock:8>,<contenttweaker:eye_of_the_nightmare>],[<botania:blazeblock>,<divinerpg:heliosis_lump>,<botania:blazeblock>]]);
 

--- a/overrides/scripts/EnderUtilities.zs
+++ b/overrides/scripts/EnderUtilities.zs
@@ -177,6 +177,11 @@ recipes.addShaped(<enderutilities:linkcrystal:1>, [[null,<enderio:item_material:
 recipes.remove(<enderutilities:linkcrystal:2>);
 recipes.addShaped(<enderutilities:linkcrystal:2>, [[null,<enderio:item_material:18>,null],[<enderio:item_material:18>,<enderutilities:enderpart:2>,<enderio:item_material:18>],[null,<enderio:item_material:18>,null]]);
 
+# NBT-clearing recipes for Link Crystals
+recipes.addHiddenShapeless("ender_utils_clear_crystal_location", <enderutilities:linkcrystal>, [<enderutilities:linkcrystal>]);
+recipes.addHiddenShapeless("ender_utils_clear_crystal_block", <enderutilities:linkcrystal:1>, [<enderutilities:linkcrystal:1>]);
+recipes.addHiddenShapeless("ender_utils_clear_crystal_portal", <enderutilities:linkcrystal:2>, [<enderutilities:linkcrystal:2>]);
+
 # Wand of the Lazy Builder (W.o.t.L.B.)
 recipes.remove(<enderutilities:builderswand>);
 recipes.addShapedMirrored(<enderutilities:builderswand>, [[null,null,<enderutilities:enderpart:17>],[null,<extrautils2:itembuilderswand>,null],[<enderutilities:enderpart:20>,null,null]]);
@@ -348,7 +353,7 @@ function(out,ins,cInfo) {
 		if(ins.black_hole_unit.tag has "stack_nbt") {
 			item_nbt = {tag: ins.black_hole_unit.tag.stack_nbt};
 		}
-		return out.withTag({Items: [{Slot: 0 as byte, id: ins.black_hole_unit.tag.itemstack, Count: ins.black_hole_unit.tag.amount as byte} + item_nbt + {Damage: ins.black_hole_unit.tag.meta as short}]});	
+		return out.withTag({Items: [{Slot: 0 as byte, id: ins.black_hole_unit.tag.itemstack, Count: ins.black_hole_unit.tag.amount as byte} + item_nbt + {Damage: ins.black_hole_unit.tag.meta as short}]});
 	} else {
 		return out;
 }}, null);

--- a/overrides/scripts/EvilCraft.zs
+++ b/overrides/scripts/EvilCraft.zs
@@ -297,7 +297,7 @@ recipes.addShaped(<evilcraft:blood_pearl_of_teleportation>.withTag({}), [[<evilc
 
 # Vengeance Pickaxe
 recipes.remove(<evilcraft:vengeance_pickaxe>);
-recipes.addShaped(<evilcraft:vengeance_pickaxe>.withTag({ench: [{lvl: 5 as short, id: 35 as short}, {lvl: 3 as short, id: 58 as short}]}), [[<contenttweaker:offensive_core>,<minecraft:diamond_block>,<contenttweaker:offensive_core>],[<minecraft:diamond_block>,<evilcraft:dark_stick>,<minecraft:diamond_block>],[null,<evilcraft:dark_stick>,null]]);
+recipes.addShaped(<evilcraft:vengeance_pickaxe>.withTag({ench: [{lvl: 5 as short, id: 35 as short}, {lvl: 3 as short, id: 47 as short}]}), [[<contenttweaker:offensive_core>,<minecraft:diamond_block>,<contenttweaker:offensive_core>],[<minecraft:diamond_block>,<evilcraft:dark_stick>,<minecraft:diamond_block>],[null,<evilcraft:dark_stick>,null]]);
 
 # Burning GemStone
 furnace.remove(<evilcraft:burning_gem_stone>);
@@ -330,12 +330,12 @@ mods.evilcraft.BloodInfuser.removeRecipesWithOutput(<evilcraft:bound_blood_drop>
 
 # Creative Blood Droplet
 mods.extendedcrafting.TableCrafting.addShaped(<evilcraft:creative_blood_drop>.withTag({}),
-[[null, null, null, <bloodmagic:decorative_brick>, null, null, null], 
-[null, null, <bloodmagic:decorative_brick>, <evilcraft:blood_orb:1>, <bloodmagic:decorative_brick>, null, null], 
-[null, <bloodmagic:decorative_brick>, <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <bloodmagic:decorative_brick>, null], 
-[null, <evilcraft:blood_orb:1>, <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <thermalexpansion:reservoir:32000>, <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <evilcraft:blood_orb:1>, null], 
-[null, <bloodmagic:decorative_brick>, <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <bloodmagic:decorative_brick>, null], 
-[null, <bloodmagic:decorative_brick>, <bloodmagic:decorative_brick>, <evilcraft:blood_orb:1>, <bloodmagic:decorative_brick>, <bloodmagic:decorative_brick>, null], 
+[[null, null, null, <bloodmagic:decorative_brick>, null, null, null],
+[null, null, <bloodmagic:decorative_brick>, <evilcraft:blood_orb:1>, <bloodmagic:decorative_brick>, null, null],
+[null, <bloodmagic:decorative_brick>, <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <bloodmagic:decorative_brick>, null],
+[null, <evilcraft:blood_orb:1>, <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <thermalexpansion:reservoir:32000>, <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <evilcraft:blood_orb:1>, null],
+[null, <bloodmagic:decorative_brick>, <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <openblocks:tank>.withTag({tank: {FluidName: "evilcraftblood", Amount: 16000}}), <bloodmagic:decorative_brick>, null],
+[null, <bloodmagic:decorative_brick>, <bloodmagic:decorative_brick>, <evilcraft:blood_orb:1>, <bloodmagic:decorative_brick>, <bloodmagic:decorative_brick>, null],
 [null, null, <bloodmagic:decorative_brick>, <bloodmagic:decorative_brick>, <bloodmagic:decorative_brick>, null, null]]);
 
 print("ENDING EvilCraft.zs");

--- a/overrides/scripts/ExtraCells2.zs
+++ b/overrides/scripts/ExtraCells2.zs
@@ -108,42 +108,41 @@ function addExtraCellsGasDisableString(item as IItemStack) {
 
 # Gas Storage Housing
 recipes.remove(<extracells:storage.casing:2>);
-recipes.addShapeless(<extracells:storage.casing:2>.withTag({fuzzyMode: "IGNORE_ALL"}), );
 recipes.addShaped(<extracells:storage.casing:2>, [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,null,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
 
 # ME 1k Gas Storage Cell
 recipes.remove(<extracells:storage.gas>);
-recipes.addShapeless(<extracells:storage.gas>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:11>);
+recipes.addShapeless(<extracells:storage.gas>.withTag({fuzzyMode: "IGNORE_ALL"}), [<extracells:storage.casing:2>, <extracells:storage.component:11>]);
 recipes.addShaped(<extracells:storage.gas>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:11>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
 
 # ME 4k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:1>);
-recipes.addShapeless(<extracells:storage.gas:1>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:12>);
+recipes.addShapeless(<extracells:storage.gas:1>.withTag({fuzzyMode: "IGNORE_ALL"}), [<extracells:storage.casing:2>, <extracells:storage.component:12>]);
 recipes.addShaped(<extracells:storage.gas:1>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:12>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
 
 # ME 16k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:2>);
-recipes.addShapeless(<extracells:storage.gas:2>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:13>);
+recipes.addShapeless(<extracells:storage.gas:2>.withTag({fuzzyMode: "IGNORE_ALL"}), [<extracells:storage.casing:2>, <extracells:storage.component:13>]);
 recipes.addShaped(<extracells:storage.gas:2>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:13>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
 
 # ME 64k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:3>);
-recipes.addShapeless(<extracells:storage.gas:3>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:14>);
+recipes.addShapeless(<extracells:storage.gas:3>.withTag({fuzzyMode: "IGNORE_ALL"}), [<extracells:storage.casing:2>, <extracells:storage.component:14>]);
 recipes.addShaped(<extracells:storage.gas:3>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:14>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
 
 # ME 256k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:4>);
-recipes.addShapeless(<extracells:storage.gas:4>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:15>);
+recipes.addShapeless(<extracells:storage.gas:4>.withTag({fuzzyMode: "IGNORE_ALL"}), [<extracells:storage.casing:2>, <extracells:storage.component:15>]);
 recipes.addShaped(<extracells:storage.gas:4>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:15>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
 
 # ME 1024k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:5>);
-recipes.addShapeless(<extracells:storage.gas:5>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:16>);
+recipes.addShapeless(<extracells:storage.gas:5>.withTag({fuzzyMode: "IGNORE_ALL"}), [<extracells:storage.casing:2>, <extracells:storage.component:16>]);
 recipes.addShaped(<extracells:storage.gas:5>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:16>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
 
 # ME 4096k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:6>);
-recipes.addShapeless(<extracells:storage.gas:6>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:17>);
+recipes.addShapeless(<extracells:storage.gas:6>.withTag({fuzzyMode: "IGNORE_ALL"}), [<extracells:storage.casing:2>, <extracells:storage.component:17>]);
 recipes.addShaped(<extracells:storage.gas:6>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:17>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
 
 # ME Gas Level Emitter

--- a/overrides/scripts/ExtraCells2.zs
+++ b/overrides/scripts/ExtraCells2.zs
@@ -108,43 +108,43 @@ function addExtraCellsGasDisableString(item as IItemStack) {
 
 # Gas Storage Housing
 recipes.remove(<extracells:storage.casing:2>);
+recipes.addShapeless(<extracells:storage.casing:2>.withTag({fuzzyMode: "IGNORE_ALL"}), );
 recipes.addShaped(<extracells:storage.casing:2>, [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,null,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
-#addExtraCellsGasDisableString(<extracells:storage.casing:2>);
 
 # ME 1k Gas Storage Cell
 recipes.remove(<extracells:storage.gas>);
+recipes.addShapeless(<extracells:storage.gas>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:11>);
 recipes.addShaped(<extracells:storage.gas>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:11>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
-#addExtraCellsGasDisableString(<extracells:storage.gas>);
 
 # ME 4k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:1>);
+recipes.addShapeless(<extracells:storage.gas:1>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:12>);
 recipes.addShaped(<extracells:storage.gas:1>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:12>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
-#addExtraCellsGasDisableString(<extracells:storage.gas:1>);
 
 # ME 16k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:2>);
+recipes.addShapeless(<extracells:storage.gas:2>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:13>);
 recipes.addShaped(<extracells:storage.gas:2>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:13>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
-#addExtraCellsGasDisableString(<extracells:storage.gas:2>);
 
 # ME 64k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:3>);
+recipes.addShapeless(<extracells:storage.gas:3>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:14>);
 recipes.addShaped(<extracells:storage.gas:3>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:14>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
-#addExtraCellsGasDisableString(<extracells:storage.gas:3>);
 
 # ME 256k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:4>);
+recipes.addShapeless(<extracells:storage.gas:4>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:15>);
 recipes.addShaped(<extracells:storage.gas:4>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:15>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
-#addExtraCellsGasDisableString(<extracells:storage.gas:4>);
 
 # ME 1024k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:5>);
+recipes.addShapeless(<extracells:storage.gas:5>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:16>);
 recipes.addShaped(<extracells:storage.gas:5>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:16>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
-#addExtraCellsGasDisableString(<extracells:storage.gas:5>);
 
 # ME 4096k Gas Storage Cell
 recipes.remove(<extracells:storage.gas:6>);
+recipes.addShapeless(<extracells:storage.gas:6>.withTag({fuzzyMode: "IGNORE_ALL"}), <extracells:storage.casing:2>, <extracells:storage.component:17>);
 recipes.addShaped(<extracells:storage.gas:6>.withTag({fuzzyMode: "IGNORE_ALL"}), [[empowered_glod_crystal,<thermalfoundation:material:72>,empowered_glod_crystal],[<thermalfoundation:material:72>,<extracells:storage.component:17>,<thermalfoundation:material:72>],[<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0}),<mekanism:gastank>.withTag({tier: 0})]]);
-#addExtraCellsGasDisableString(<extracells:storage.gas:6>);
 
 # ME Gas Level Emitter
 recipes.remove(<extracells:part.base:17>);

--- a/overrides/scripts/IndustrialForegoing.zs
+++ b/overrides/scripts/IndustrialForegoing.zs
@@ -224,6 +224,11 @@ addIFRangeAddonRecipe(<industrialforegoing:range_addon:10>, <thermalfoundation:m
 # Range Addon +12
 addIFRangeAddonRecipe(<industrialforegoing:range_addon:11>, <minecraft:emerald>, <industrialforegoing:range_addon:10>);
 
+# Change Range Addon Stack Size
+for i in 0 to 11 {
+	<industrialforegoing:range_addon>.definition.makeStack(i).maxStackSize = 64;
+}
+
 # Adult Filter
 recipes.remove(<industrialforegoing:adult_filter>);
 recipes.addShaped(<industrialforegoing:adult_filter>, [[<enderio:item_alloy_ingot>,<industrialforegoing:plastic>,<enderio:item_alloy_ingot>],[<enderio:item_alloy_ingot:4>,<minecraft:egg>,<enderio:item_alloy_ingot:4>],[<enderio:item_alloy_ingot>,<industrialforegoing:plastic>,<enderio:item_alloy_ingot>]]);
@@ -300,7 +305,7 @@ recipes.addShaped(<industrialforegoing:laser_base>, [[<industrialforegoing:plast
 recipes.remove(<industrialforegoing:laser_drill>);
 recipes.addShaped(<industrialforegoing:laser_drill>, [[<industrialforegoing:plastic>,<contenttweaker:steaming_restonia_crystal>,<industrialforegoing:plastic>],[<contenttweaker:steaming_restonia_crystal>,<teslacorelib:machine_case>,<contenttweaker:steaming_restonia_crystal>],[<industrialforegoing:plastic>,<contenttweaker:steaming_restonia_crystal>,<industrialforegoing:plastic>]]);
 
-# Pink Slime 
+# Pink Slime
 <ore:slimeball>.remove(<industrialforegoing:pink_slime>);
 recipes.addShaped(<industrialforegoing:pink_slime> * 8, [[<mysticalagriculture:slime_essence>,<ore:dyePink>,<mysticalagriculture:slime_essence>],[<ore:dyePink>,<mysticalagriculture:slime_essence>,<ore:dyePink>],[<mysticalagriculture:slime_essence>,<ore:dyePink>,<mysticalagriculture:slime_essence>]]);
 

--- a/overrides/scripts/MoreTweaker.zs
+++ b/overrides/scripts/MoreTweaker.zs
@@ -5,10 +5,9 @@ import moretweaker.jei.MoreJei;
 print("STARTING MoreTweaker.zs");
 
 # Remove various Information pages
-# MoreJei.removeDescription(IIngredient input);
 MoreJei.removeDescription(<minecraft:diamond>);
 MoreJei.removeDescription(<minecraft:gold_ingot>);
-MoreJei.removeDescription(<enderio:material:81>);
+MoreJei.removeDescription(<enderio:item_material:81>);
 MoreJei.removeDescription(<enderio:block_inventory_panel>);
 MoreJei.removeDescription(<enderio:block_inventory_panel_sensor>);
 MoreJei.removeDescription(<enderio:item_inventory_remote>);
@@ -19,5 +18,6 @@ MoreJei.removeDescription(<enderio:item_gas_conduit:1>);
 MoreJei.removeDescription(<enderio:item_dark_steel_treetap>);
 MoreJei.removeDescription(<thaumcraft:salis_mundus>);
 MoreJei.removeDescription(<thaumcraft:crystal_essence>);
+MoreJei.removeDescription(<extrautils2:ingredients:10>);
 
 print("ENDING MoreTweaker.zs");

--- a/overrides/scripts/MoreTweaker.zs
+++ b/overrides/scripts/MoreTweaker.zs
@@ -1,0 +1,23 @@
+# Author: WaitingIdly
+
+import moretweaker.jei.MoreJei;
+
+print("STARTING MoreTweaker.zs");
+
+# Remove various Information pages
+# MoreJei.removeDescription(IIngredient input);
+MoreJei.removeDescription(<minecraft:diamond>);
+MoreJei.removeDescription(<minecraft:gold_ingot>);
+MoreJei.removeDescription(<enderio:material:81>);
+MoreJei.removeDescription(<enderio:block_inventory_panel>);
+MoreJei.removeDescription(<enderio:block_inventory_panel_sensor>);
+MoreJei.removeDescription(<enderio:item_inventory_remote>);
+MoreJei.removeDescription(<enderio:item_inventory_remote:1>);
+MoreJei.removeDescription(<enderio:item_inventory_remote:2>);
+MoreJei.removeDescription(<enderio:item_gas_conduit>);
+MoreJei.removeDescription(<enderio:item_gas_conduit:1>);
+MoreJei.removeDescription(<enderio:item_dark_steel_treetap>);
+MoreJei.removeDescription(<thaumcraft:salis_mundus>);
+MoreJei.removeDescription(<thaumcraft:crystal_essence>);
+
+print("ENDING MoreTweaker.zs");


### PR DESCRIPTION
Mod updates, balance changes, bugfixes, quest tweaks, and some QoL included.

<h1>Changes:</h1>

<h2>Mod Updates:</h2>
DJ2Addons: 1.0.1 -> 1.1.0<br>
Thaumic Augmentation: 2.1.5 -> 2.1.7<br>
Roots: 3.1.4 -> 3.1.5<br>
UB: 1.3.11 -> 1.3.14<br>
ModTweaker: 4.0.20.4 -> 4.0.20.11<br>
CraftTweaker: 4.1.20.674 -> 4.1.20.675<br>
UniDict: 3.0.8 -> 3.0.10<br>
JEI: 4.16.1.301 -> 4.16.1.302<br>
LibVulpes: build -84 -> build -25<br>
WanionLib: 2.5 -> 2.9<br>
Hammer Lib: 2.0.6.28 -> 2.0.6.32<br>

<h2>Bugfixes:</h2>
Fix Gas Storage Housing uses being missing.<br>
EnderIO Attractor Crystal recipe is now actually craftable.<br>
Fix Evilcraft's Vengeance Pickaxe crafting with an incorrect enchantment.<br>
Glod Blocks now drop the correct NBT tagged Glod Block.<br>
Fix Roots Bowl duplication glitch.<br>


<h2>Balance Changes:</h2>
Moved higher tiers of Blood Magic's Incense Altar earlier, adjusted their recipes.<br>
Add Saturation providing Botania Brews, comes in all variants (potion, Incense Stick, and Tainted Blood Pendant).<br>
Add Warp Ward providing Botania Tainted Blood Pendant, but nerf the Warp Ward recipe (this allows permanent negation of negative Warp effects at a slight mana upkeep cost).<br>
Add a Warp Ward recipe obtainable early in Vethea because warp carries over.<br>
Move the Unwarpification Talisman significantly earlier, into mid-Astral Sorcery (Chapter 28 -> 23).<br>
Enchanted Golden Berries cost was reduced.<br>
Reduce Spatial Storage component costs.<br>


<h2>QoL:</h2>
Crafting the Tier I /Dank/Null now crafts with Soulbound 10.<br>
Increase the stack size of Industrial Foregoing Range Addons to 64.<br>
Remove a number of incorrect item descriptions from the JEI tab.<br>
NBT removal recipes for Ender Utilities Link Crystals.<br>
Add more types of zombies to the EnderIO Z-Logic Controller.<br>


<h2>Text changes and quest fixes:</h2>
Adjusted and added quests relevant to balance changes.<br>
(Chapter 11) Add a quest for RFTools Powercells.<br>
(Chapter 21) Improved the description of "Molding the Void".<br>
(Chapter 22) Fix incorrect boss name in "Heliosis' Dream".<br>
(Chapter 22) Fix an incorrect quest amount requirement in "Zappy!".<br>
(Chapter 24) Fix a typo in "Wait WHAT? Aliens?".<br>
