### PR TITLE
Disable roots tools on custom dungeon blocks

### DIFF
--- a/overrides/config/roots/tools.cfg
+++ b/overrides/config/roots/tools.cfg
@@ -68,6 +68,72 @@ tools {
         thaumicaugmentation:stone:5
         thaumicaugmentation:stone:9
         thaumicaugmentation:stone:11
+        contenttweaker:eden_stone
+        contenttweaker:eden_bricks
+        contenttweaker:eden_pillar
+        contenttweaker:eden_floor
+        contenttweaker:eden_roof
+        contenttweaker:eden_glass
+        contenttweaker:eden_door
+        contenttweaker:wildwood_stone
+        contenttweaker:wildwood_bricks
+        contenttweaker:wildwood_pillar
+        contenttweaker:wildwood_floor
+        contenttweaker:wildwood_roof
+        contenttweaker:wildwood_glass
+        contenttweaker:wildwood_door
+        contenttweaker:apalachia_stone
+        contenttweaker:apalachia_bricks
+        contenttweaker:apalachia_pillar
+        contenttweaker:apalachia_floor
+        contenttweaker:apalachia_roof
+        contenttweaker:apalachia_glass
+        contenttweaker:apalachia_door
+        contenttweaker:skythern_stone
+        contenttweaker:skythern_bricks
+        contenttweaker:skythern_pillar
+        contenttweaker:skythern_floor
+        contenttweaker:skythern_roof
+        contenttweaker:skythern_glass
+        contenttweaker:skythern_door
+        contenttweaker:mortum_stone
+        contenttweaker:mortum_bricks
+        contenttweaker:mortum_pillar
+        contenttweaker:mortum_floor
+        contenttweaker:mortum_roof
+        contenttweaker:mortum_glass
+        contenttweaker:mortum_door
+        contenttweaker:moon_stone
+        contenttweaker:moon_bricks
+        contenttweaker:moon_pillar
+        contenttweaker:moon_floor
+        contenttweaker:moon_roof
+        contenttweaker:moon_glass
+        contenttweaker:moon_door
+        contenttweaker:mars_stone
+        contenttweaker:mars_bricks
+        contenttweaker:mars_pillar
+        contenttweaker:mars_floor
+        contenttweaker:mars_roof
+        contenttweaker:mars_glass
+        contenttweaker:mars_door
+        contenttweaker:venus_stone
+        contenttweaker:venus_bricks
+        contenttweaker:venus_pillar
+        contenttweaker:venus_floor
+        contenttweaker:venus_roof
+        contenttweaker:venus_glass
+        contenttweaker:venus_door
+        contenttweaker:asteroids_stone
+        contenttweaker:asteroids_bricks
+        contenttweaker:asteroids_pillar
+        contenttweaker:asteroids_floor
+        contenttweaker:asteroids_roof
+        contenttweaker:asteroids_glass
+        contenttweaker:asteroids_door
+        contenttweaker:apalachia_door2
+        contenttweaker:skythern_door2
+        contenttweaker:venus_door2
      >
 
     # Terrastone Shovel has silk touch on grass, mycelium and podzol by default


### PR DESCRIPTION
I had thought this was done and fixed months ago. Ah well.