### PR TITLE
Minor Tooltip additions

### DIFF
--- a/overrides/scripts/StorageDrawers.zs
+++ b/overrides/scripts/StorageDrawers.zs
@@ -1,4 +1,9 @@
-# Author: Atricos
+# Author: Atricos, WaitingIdly
+
+import crafttweaker.item.IItemStack;
+import crafttweaker.item.ITooltipFunction;
+import crafttweaker.data.IData;
+
 print("STARTING StorageDrawers.zs");
 
 # Framing Table
@@ -51,5 +56,143 @@ mods.extendedcrafting.TableCrafting.addShaped(<storagedrawers:upgrade_creative:1
 
 # Remove recipes for all Storage Drawers Extras
 recipes.removeByMod("storagedrawersextra");
+
+# Drawer Tooltips
+function getNested(inTag as IData, keys as string[], alt as IData) as IData {
+    var tag = inTag;
+    for key in keys {
+        if (isNull(tag)) return alt;
+        tag = tag.memberGet(key);
+    }
+    return isNull(tag) ? alt : tag;
+}
+
+# Indicate materials framing Framed Drawers
+function makeTagFunc(name as string) as ITooltipFunction {
+    val matTag = "Mat" + name[0];
+    return function(stack as IItemStack) as string {
+        if (isNull(stack) || isNull(stack.tag) || isNull(stack.tag.memberGet(matTag))) return "§e" + name + ": §r§c-§r";
+        val data as IData = stack.tag.memberGet(matTag);
+        val item as IItemStack = itemUtils.getItem(data.id, data.Damage);
+        return "§e" + name + ": §r" + (isNull(item) ? "§c-§r" : item.displayName);
+    } as ITooltipFunction;
+}
+
+# Format item & amount
+function contents(name as string, count as int) as string {
+    return "§c" + count + "§r §6" + name + "§r";
+}
+
+# Convert an array of strings into a comma separated string, with a custom joiner if >2 entries. Uses an Oxford Comma
+function arrayToList(list as string[], joiner as string) as string {
+    var output as string = "";
+    for index, entry in list {
+        output += entry;
+        if (index == list.length - 1) output += ".";
+        else if (index == list.length - 2 && list.length > 2) output += ", §b" + joiner + "§r ";
+        else if (index == list.length - 2) output += " §b" + joiner + "§r ";
+        else output += ", ";
+    }
+    return output;
+}
+
+# Metadata to Multiplier for Drawer Upgrades
+static upgradeMultiplier as int[int] = {
+    0:  2,
+    1:  4,
+    2:  8,
+    3: 16,
+    4: 32,
+} as int[int];
+
+# Determine the current capacity of a drawer using its current upgrades based on an input base.
+function capacity(passBase as int) as ITooltipFunction {
+    return function(drawer as IItemStack) as string {
+        val g as IData = getNested(drawer.tag, ["tile", "Upgrades"], []);
+
+        var base = passBase;
+        var total = 0;
+        for x in g.asList() {
+            if (isNull(x)) continue;
+            if (x.id == "storagedrawers:upgrade_storage") total += upgradeMultiplier[x.Damage];
+            else if (x.id == "storagedrawers:upgrade_one_stack") base = 1;
+            else if (x.id == "storagedrawers:upgrade_creative" && x.Damage == 0) return "Infinite Storage";
+            else if (x.id == "storagedrawers:upgrade_creative" && x.Damage == 1) return "Vending";
+        }
+        val capacity = (base * (total > 0 ? total : 1));
+        return "Capacity: §c" + capacity + "§r stack" + (capacity == 1 ? "" : "s");
+    } as ITooltipFunction;
+}
+
+# Convert a non-compacting drawer into a comma separated list containing all its items.
+# Note that multiple of the same type of item are *not* combined.
+function normalDrawer() as ITooltipFunction {
+    return function(drawer as IItemStack) as string {
+        val items as IData = getNested(drawer.tag, ["tile", "Drawers"], []);
+        if (isNull(items)) return "";
+        var end as string[] = [];
+        for i, x in items.asList() {
+            if (isNull(x) || isNull(x.Item)) continue;
+            val item as IItemStack = itemUtils.getItem(x.Item.id, x.Item.Damage);
+            end += contents(item.displayName, x.Count);
+        }
+        if (end.length == 0) return "§6Contains nothing§r";
+        return arrayToList(end, "and");
+    } as ITooltipFunction;
+}
+
+# Convert a compacting drawer into a comma separated list containing its items, indicating that the quantity is exclusive between types.
+function compactingDrawer() as ITooltipFunction {
+    return function(drawer as IItemStack) as string {
+        val count as IData = getNested(drawer.tag, ["tile", "Drawers", "Count"], "0");
+
+        val items as IData = getNested(drawer.tag, ["tile", "Drawers", "Items"], []);
+        if (isNull(items) || isNull(count)) return "";
+        var end as string[] = [];
+        for i, x in items.asList() {
+            if (isNull(x) || isNull(x.Item)) continue;
+            val item as IItemStack = itemUtils.getItem(x.Item.id, x.Item.Damage);
+            end += contents(item.displayName, count / x.Conv);
+        }
+        if (end.length == 0) return "§6Contains nothing§r";
+        return arrayToList(end, "or");
+    } as ITooltipFunction;
+}
+
+# Setup the drawer tooltips
+function setupDrawerTooltip(drawer as IItemStack, trim as bool, slots as int, stack as int) {
+    if (trim) {
+        drawer.addAdvancedTooltip(makeTagFunc("Side"));
+        drawer.addAdvancedTooltip(makeTagFunc("Front"));
+        drawer.addAdvancedTooltip(makeTagFunc("Trim"));
+    }
+    if (stack > 0) {
+        drawer.removeTooltip("stacks per drawer");
+        drawer.addAdvancedTooltip(capacity(stack));
+    }
+    if (slots == 3) {
+        drawer.addAdvancedTooltip(compactingDrawer());
+    } else if (slots > 0) {
+        drawer.addAdvancedTooltip(normalDrawer());
+    }
+}
+
+setupDrawerTooltip(<storagedrawers:basicdrawers>, false, 1, 32);
+setupDrawerTooltip(<storagedrawers:basicdrawers:1>, false, 2, 16);
+setupDrawerTooltip(<storagedrawers:basicdrawers:2>, false, 4, 8);
+setupDrawerTooltip(<storagedrawers:basicdrawers:3>, false, 2, 8);
+setupDrawerTooltip(<storagedrawers:basicdrawers:4>, false, 4, 4);
+setupDrawerTooltip(<storagedrawers:customdrawers>, true, 1, 32);
+setupDrawerTooltip(<storagedrawers:customdrawers:1>, true, 2, 16);
+setupDrawerTooltip(<storagedrawers:customdrawers:2>, true, 4, 8);
+setupDrawerTooltip(<storagedrawers:customdrawers:3>, true, 2, 8);
+setupDrawerTooltip(<storagedrawers:customdrawers:4>, true, 4, 4);
+setupDrawerTooltip(<storagedrawers:compdrawers>, false, 3, 16);
+setupDrawerTooltip(<framedcompactdrawers:framed_compact_drawer>, true, 3, 16);
+setupDrawerTooltip(<framedcompactdrawers:framed_drawer_controller>, true, 0, 0);
+setupDrawerTooltip(<framedcompactdrawers:framed_slave>, true, 0, 0);
+
+<storagedrawers:customtrim>.addAdvancedTooltip(makeTagFunc("Side"));
+<storagedrawers:customtrim>.addAdvancedTooltip(makeTagFunc("Trim"));
 
 print("ENDING StorageDrawers.zs");

--- a/overrides/scripts/ThermalFoundation.zs
+++ b/overrides/scripts/ThermalFoundation.zs
@@ -45,19 +45,36 @@ recipes.addShapedMirrored(<thermalfoundation:material:515>, [[<ore:ingotRedAlloy
 recipes.remove(<thermalfoundation:material:657>);
 recipes.addShaped(<thermalfoundation:material:657>, [[<immersiveengineering:material:2>,<immersiveengineering:material:2>,<immersiveengineering:material:2>],[<immersiveengineering:material:2>,<thermalfoundation:material:352>,<immersiveengineering:material:2>],[<immersiveengineering:material:2>,<immersiveengineering:material:2>,<immersiveengineering:material:2>]]);
 
+# Add Tooltips to Kits
+function thermalKitTooltip(item as IItemStack, machine as int, container as int, box as int) {
+    item.addShiftTooltip("Increase the base energy capacity of a Machine or Dynamo by §c" ~ machine ~ "%§r of the (variable) base.");
+    item.addShiftTooltip("Increase the base fluid capacity of a Portable Tank by §cx" ~ container ~ "§r of the base of §c20,000mb§r.");
+    item.addShiftTooltip("Increase the base item capacity of a Cache by §cx" ~ container ~ "§r of the base of §c20,000§r items.");
+    item.addShiftTooltip("Increase the base slot amount of a Storage Box by §c" ~ box ~ "§r from the base of §c18§r.");
+}
+
+# Conversion Kits
+thermalKitTooltip(<thermalfoundation:upgrade:33>, 100, 9, 36);
+thermalKitTooltip(<thermalfoundation:upgrade:34>, 150, 16, 54);
+thermalKitTooltip(<thermalfoundation:upgrade:35>, 200, 25, 82);
+
 # Hardened Upgrade Kit
+thermalKitTooltip(<thermalfoundation:upgrade>, 50, 4, 18);
 recipes.remove(<thermalfoundation:upgrade>);
 recipes.addShaped(<thermalfoundation:upgrade>, [[<thermalfoundation:material:354>,<thermalfoundation:material:354>,<thermalfoundation:material:354>],[<thermalfoundation:material:354>,<thermalfoundation:material:264>,<thermalfoundation:material:354>],[<ore:ingotRedAlloy>,<ore:ingotRedAlloy>,<ore:ingotRedAlloy>]]);
 
 # Reinforced Upgrade Kit
+thermalKitTooltip(<thermalfoundation:upgrade:1>, 100, 9, 36);
 recipes.remove(<thermalfoundation:upgrade:1>);
 recipes.addShaped(<thermalfoundation:upgrade:1>, [[<contenttweaker:fluxed_electrum_plate>,<contenttweaker:fluxed_electrum_plate>,<contenttweaker:fluxed_electrum_plate>],[<contenttweaker:fluxed_electrum_plate>,<enderio:item_material:41>,<contenttweaker:fluxed_electrum_plate>],[<ore:ingotRedAlloy>,<ore:ingotRedAlloy>,<ore:ingotRedAlloy>]]);
 
 # Signalum Upgrade Kit
+thermalKitTooltip(<thermalfoundation:upgrade:2>, 150, 16, 54);
 recipes.remove(<thermalfoundation:upgrade:2>);
 recipes.addShaped(<thermalfoundation:upgrade:2>, [[<thermalfoundation:material:327>,<thermalfoundation:material:327>,<thermalfoundation:material:327>],[<thermalfoundation:material:327>,<thermalfoundation:storage_alloy:5>,<thermalfoundation:material:327>],[<thermalfoundation:material:514>,<thermalfoundation:material:514>,<thermalfoundation:material:514>]]);
 
 # Resonant Upgrade Kit
+thermalKitTooltip(<thermalfoundation:upgrade:3>, 200, 25, 82);
 recipes.remove(<thermalfoundation:upgrade:3>);
 recipes.addShaped(<thermalfoundation:upgrade:3>, [[<extendedcrafting:material:2>,<extendedcrafting:material:2>,<extendedcrafting:material:2>],[<extendedcrafting:material:2>,<thermalfoundation:storage_alloy:7>,<extendedcrafting:material:2>],[<thermalfoundation:material:515>,<thermalfoundation:material:515>,<thermalfoundation:material:515>]]);
 


### PR DESCRIPTION
- Add effectiveness tooltips to thermal kits
- Add a tooltip to most drawers indicating current stack size (based on internal upgrades), framing, and currently held items if relevant. Did this take way longer than it was worth? Extremely.