### PR TITLE
prevent bewitchment snakes from Blood Magic's WoS

### DIFF
--- a/overrides/config/bloodmagic/bloodmagic.cfg
+++ b/overrides/config/bloodmagic/bloodmagic.cfg
@@ -195,6 +195,7 @@ values {
         ocelot;100
         pig;100
         rabbit;100
+        bewitchment:snake;0
      >
 
     # Will rewrite any default meteor types with new versions.


### PR DESCRIPTION
prevents bug codename "ouroboros", wherein the snake returns to life and full health instead of dying.
death to eternity.
victory ever transient.
