### PR TITLE
resolve #930

### DIFF
--- a/overrides/config/modularmachinery/recipes/mob_loot_fabricator_passive.json
+++ b/overrides/config/modularmachinery/recipes/mob_loot_fabricator_passive.json
@@ -98,6 +98,12 @@
             "io-type": "output",
             "item": "natura:materials@6",
             "amount": 64
+        },
+        {
+            "type": "fluid",
+            "io-type": "output",
+            "fluid": "meat",
+            "amount": 8000
         }
     ]
 }

--- a/overrides/config/modularmachinery/recipes/mob_loot_fabricator_slime.json
+++ b/overrides/config/modularmachinery/recipes/mob_loot_fabricator_slime.json
@@ -1,0 +1,55 @@
+{
+    "machine": "mob_loot_fabricator",
+    "registryName": "mob_loot_fabricator_slime",
+    "recipeTime": 20,
+    "requirements": [
+        {
+            "type": "item",
+            "io-type": "input",
+            "item": "botania:slimebottle",
+            "amount": 1,
+            "chance": 0
+        },
+        {
+            "type": "lifeessence",
+            "io-type": "input",
+            "essenceamount": 500
+        },
+        {
+            "type": "item",
+            "io-type": "output",
+            "item": "minecraft:slime_ball",
+            "amount": 64
+        },
+        {
+            "type": "item",
+            "io-type": "output",
+            "item": "industrialforegoing:pink_slime",
+            "amount": 8
+        },
+        {
+            "type": "item",
+            "io-type": "output",
+            "item": "aether_legacy:swetty_ball",
+            "amount": 8
+        },
+        {
+            "type": "item",
+            "io-type": "output",
+            "item": "tconstruct:edible@1",
+            "amount": 8
+        },
+        {
+            "type": "item",
+            "io-type": "output",
+            "item": "tconstruct:edible@2",
+            "amount": 8
+        },
+        {
+            "type": "item",
+            "io-type": "output",
+            "item": "tconstruct:edible@4",
+            "amount": 8
+        }
+    ]
+}


### PR DESCRIPTION
- add liquid meat output to the passive mobs MLF recipe
- add a new slime type to the MLF, giving the 3 tinkers slimeballs, vanilla slimeballs, aether legacy swet balls, and industrial foregoing pink slime balls
- resolve #930 