### PR TITLE
resolve #941 and a storage drawer controller bug

### DIFF
--- a/overrides/config/UniversalTweaks.cfg
+++ b/overrides/config/UniversalTweaks.cfg
@@ -182,7 +182,7 @@ general {
             # type           Type of germling, can be either pollen or sapling
             # complexity_min Lower limit of allele complexity
             # complexity_max Upper limit of allele complexity
-            # 
+            #
             # Example for a level 5 trade for a single sapling with a complexity between 6 and 10, costing between 10 to 40 emeralds:
             # 5;10;40;1;1;sapling;6;10
             S:"Arborist Villager Trades" <
@@ -211,7 +211,7 @@ general {
             # Fixes voiding of items when nearing full capacity
             # Fixes slotless item handler implementation not allowing the extraction from compacting item drawers with the vending upgrade
             # Caches the drawer controller tile to avoid getting the TE from the world every time a drawer slave is interacted with
-            B:"Item Handlers"=true
+            B:"Item Handlers"=false
 
             # Approximate range in blocks at which drawers render contained items
             # 0 for default unlimited range
@@ -457,7 +457,7 @@ general {
 
         "item entities" {
             # Enables the modification of item entity properties
-            B:"[01] Item Entities Toggle"=true
+            B:"[01] Item Entities Toggle"=false
 
             # Adds physical aspects such as collision boxes to item entities
             B:"[02] Physics"=false


### PR DESCRIPTION
This disables two Universal Tweaks features:
- The Storage Drawers "Item Handlers" tweak, as it causes issues with Drawer Controller insertion.
- The Item Entities tweak, as the combination of itemstacks breaks some setups - most notably Botania. Resolves #941.
