### PR TITLE
improve UB ores behavior on being silk touched

### DIFF
--- a/overrides/config/undergroundbiomes/ores/astralsorcery.json
+++ b/overrides/config/undergroundbiomes/ores/astralsorcery.json
@@ -5,22 +5,6 @@
     "overlay": "undergroundbiomes:blocks/overlays/astralsorcery/aquamarine",
     "lightValue": -1,
     "alphaOverlay": false,
-    "oreDirectories": []
-  },
-  {
-    "internalOreName": "astralsorcery:blockcustomore",
-    "meta": 0,
-    "overlay": "undergroundbiomes:blocks/overlays/astralsorcery/rockcrystal",
-    "lightValue": -1,
-    "alphaOverlay": false,
-    "oreDirectories": []
-  },
-  {
-    "internalOreName": "astralsorcery:blockcustomore",
-    "meta": 1,
-    "overlay": "undergroundbiomes:blocks/overlays/astralsorcery/starmetal",
-    "lightValue": -1,
-    "alphaOverlay": false,
-    "oreDirectories": []
+    "oreDirectories": ["oreAquamarine"]
   }
 ]

--- a/overrides/config/undergroundbiomes/ores/thermalfoundation.json
+++ b/overrides/config/undergroundbiomes/ores/thermalfoundation.json
@@ -49,14 +49,6 @@
   },
   {
     "internalOreName": "thermalfoundation:ore",
-    "meta": 6,
-    "overlay": "undergroundbiomes:blocks/overlays/thermalfoundation/platinum",
-    "lightValue": -1,
-    "alphaOverlay": false,
-    "oreDirectories": []
-  },
-  {
-    "internalOreName": "thermalfoundation:ore",
     "meta": 7,
     "overlay": "undergroundbiomes:blocks/overlays/thermalfoundation/iridium",
     "lightValue": -1,

--- a/overrides/scripts/Events.zs
+++ b/overrides/scripts/Events.zs
@@ -60,7 +60,6 @@ static oreConversion as IItemStack[string] = {
     oreTin: <thermalfoundation:ore:1>,
     oreUranium: <immersiveengineering:ore:5>,
     oreYellorite: <bigreactors:oreyellorite>,
-    oreYellorium: <bigreactors:oreyellorite>,
 } as IItemStack[string];
 
 static correctOreDict as string[] = [
@@ -70,12 +69,17 @@ static correctOreDict as string[] = [
 
 
 events.onBlockHarvestDrops(function(e as BlockHarvestDropsEvent) {
-    if (e.player.world.isRemote()) {
+    if (e.world.isRemote()) {
+        return;
+    }
+
+    // If we aren't a player or aren't harvesting with Silk Touch, return early.
+    if (!e.isPlayer || !e.silkTouch) {
         return;
     }
 
     // If we are using silk touch on UB ores, give the ore block of the mod the ore is from instead of the UB %stonetype% ore block.
-    if (e.silkTouch && e.drops.length == 1 && e.block.definition.id.startsWith("undergroundbiomes")) {
+    if (e.drops.length == 1 && e.block.definition.id.startsWith("undergroundbiomes")) {
         var ores = e.drops[0].stack.ores;
         if (!isNull(ores)) {
             if (ores.length == 1) {

--- a/overrides/scripts/Events.zs
+++ b/overrides/scripts/Events.zs
@@ -3,6 +3,7 @@
 
 import crafttweaker.event.PlayerInteractEntityEvent;
 import crafttweaker.event.PlayerInteractBlockEvent;
+import crafttweaker.event.BlockHarvestDropsEvent;
 import crafttweaker.event.BlockBreakEvent;
 import crafttweaker.event.CommandEvent;
 import crafttweaker.world.IBlockPos;
@@ -11,9 +12,88 @@ import crafttweaker.entity.IEntityEquipmentSlot;
 import crafttweaker.player.IPlayer;
 import crafttweaker.data.IData;
 import crafttweaker.item.IItemStack;
+import crafttweaker.item.WeightedItemStack;
+import crafttweaker.oredict.IOreDictEntry;
 import mods.contenttweaker.Commands;
 import mods.zenutils.command.CommandUtils;
 import mods.zenutils.I18n;
+
+static oreConversion as IItemStack[string] = {
+    oreAluminum: <thermalfoundation:ore:4>,
+    oreAmber: <thaumcraft:ore_amber>,
+    oreAmethyst: <mysticalworld:amethyst_ore>,
+    oreAquamarine: <astralsorcery:blockcustomsandore>,
+    oreArlemite: <divinerpg:arlemite_ore>,
+    oreAstralStarmetal: <astralsorcery:blockcustomore:1>,
+    oreCertusQuartz: <appliedenergistics2:quartz_ore>,
+    oreChargedCertusQuartz: <appliedenergistics2:charged_quartz_ore>,
+    oreCinnabar: <thaumcraft:ore_cinnabar>,
+    oreClathrateOilShale: <thermalfoundation:ore_fluid:1>,
+    oreClathrateRedstone: <thermalfoundation:ore_fluid:2>,
+    oreCoal: <minecraft:coal_ore>,
+    oreCopper: <thermalfoundation:ore>,
+    oreCoralium: <abyssalcraft:coraliumore>,
+    oreDark: <evilcraft:dark_ore>,
+    oreDiamond: <minecraft:diamond_ore>,
+    oreDimensionalShard: <rftools:dimensional_shard_ore>,
+    oreDraconium: <draconicevolution:draconium_ore>,
+    oreEmerald: <minecraft:emerald_ore>,
+    oreGarnet: <bewitchment:garnet_ore>,
+    oreGold: <minecraft:gold_ore>,
+    oreInferium: <mysticalagriculture:inferium_ore>,
+    oreIridium: <thermalfoundation:ore:7>,
+    oreIron: <minecraft:iron_ore>,
+    oreLapis: <minecraft:lapis_ore>,
+    oreLead: <thermalfoundation:ore:3>,
+    oreMithril: <thermalfoundation:ore:8>,
+    oreNickel: <thermalfoundation:ore:5>,
+    oreOpal: <bewitchment:opal_ore>,
+    oreOsmium: <mekanism:oreblock>,
+    oreOverworldQuartz: <thaumcraft:ore_quartz>,
+    orePlatinum: <thermalfoundation:ore:6>,
+    oreProsperity: <mysticalagriculture:prosperity_ore>,
+    oreQuartzBlack: <actuallyadditions:block_misc:3>,
+    oreRealmite: <divinerpg:realmite_ore>,
+    oreRedstone: <minecraft:redstone_ore>,
+    oreRupee: <divinerpg:rupee_ore>,
+    oreSilver: <thermalfoundation:ore:2>,
+    oreTin: <thermalfoundation:ore:1>,
+    oreUranium: <immersiveengineering:ore:5>,
+    oreYellorite: <bigreactors:oreyellorite>,
+    oreYellorium: <bigreactors:oreyellorite>,
+} as IItemStack[string];
+
+static correctOreDict as string[] = [
+    "oreYellorite",
+    "oreChargedCertusQuartz"
+] as string[];
+
+
+events.onBlockHarvestDrops(function(e as BlockHarvestDropsEvent) {
+    if (e.player.world.isRemote()) {
+        return;
+    }
+
+    // If we are using silk touch on UB ores, give the ore block of the mod the ore is from instead of the UB %stonetype% ore block.
+    if (e.silkTouch && e.drops.length == 1 && e.block.definition.id.startsWith("undergroundbiomes")) {
+        var ores = e.drops[0].stack.ores;
+        if (!isNull(ores)) {
+            if (ores.length == 1) {
+                val desiredDrop = oreConversion[ores[0].name];
+                if (!isNull(desiredDrop)) e.drops = [desiredDrop] as WeightedItemStack[];
+            } else if (ores.length >= 1) {
+                // If we have multiple oredicts possible, iterate through until we find the predetermined "correct" oredict
+                for ore in ores {
+                    if (correctOreDict has ore.name) {
+                        val desiredDrop = oreConversion[ore.name];
+                        if (!isNull(desiredDrop)) e.drops = [desiredDrop] as WeightedItemStack[];
+                        break;
+                    }
+                }
+            }
+        }
+    }
+});
 
 static astralTiers as string[] = [
     "BASIC_CRAFT",

--- a/overrides/scripts/OreProcessingAdditions.zs
+++ b/overrides/scripts/OreProcessingAdditions.zs
@@ -717,7 +717,6 @@ val UBAluminumOres = [<undergroundbiomes:igneous_stone_immersiveengineering_ore_
 val UBLapisOres = [<undergroundbiomes:igneous_stone_lapis_ore:*>,<undergroundbiomes:metamorphic_stone_lapis_ore:*>,<undergroundbiomes:sedimentary_stone_lapis_ore:*>] as IItemStack[];
 #val UBMithrilOres = [<undergroundbiomes:igneous_stone_tile.thermalfoundation.ore.mithril.name:*>,<undergroundbiomes:metamorphic_stone_tile.thermalfoundation.ore.mithril.name:*>,<undergroundbiomes:sedimentary_stone_tile.thermalfoundation.ore.mithril.name:*>] as IItemStack[];
 val UBRedstoneOres = [<undergroundbiomes:igneous_stone_redstone_ore:*>,<undergroundbiomes:metamorphic_stone_redstone_ore:*>,<undergroundbiomes:sedimentary_stone_redstone_ore:*>] as IItemStack[];
-val UBPlatinumOres = [<undergroundbiomes:igneous_stone_tile.thermalfoundation.ore.platinum.name:*>,<undergroundbiomes:metamorphic_stone_tile.thermalfoundation.ore.platinum.name:*>,<undergroundbiomes:sedimentary_stone_tile.thermalfoundation.ore.platinum.name:*>] as IItemStack[];
 val UBDimensionalShardOres = [<undergroundbiomes:igneous_stone_rftools_dimensional_shard_ore:*>,<undergroundbiomes:metamorphic_stone_rftools_dimensional_shard_ore:*>,<undergroundbiomes:sedimentary_stone_rftools_dimensional_shard_ore:*>] as IItemStack[];
 val UBDiamondOres = [<undergroundbiomes:igneous_stone_diamond_ore:*>,<undergroundbiomes:metamorphic_stone_diamond_ore:*>,<undergroundbiomes:sedimentary_stone_diamond_ore:*>] as IItemStack[];
 val UBDraconiumOres = [<undergroundbiomes:igneous_stone_draconicevolution_draconium_ore:*>,<undergroundbiomes:metamorphic_stone_draconicevolution_draconium_ore:*>,<undergroundbiomes:sedimentary_stone_draconicevolution_draconium_ore:*>] as IItemStack[];
@@ -771,9 +770,6 @@ for o in UBLapisOres {
 #}
 for o in UBRedstoneOres {
 	mods.mekanism.enrichment.addRecipe(o, <minecraft:redstone> * 12);
-}
-for o in UBPlatinumOres {
-	mods.mekanism.enrichment.addRecipe(o, <thermalfoundation:material:70> * 2);
 }
 for o in UBDimensionalShardOres {
 	mods.mekanism.enrichment.addRecipe(o, <rftools:dimensional_shard> * 4);


### PR DESCRIPTION
- Remove Thermal Foundation Platinum, Astral Sorcery Rock Crystal, and Astral Sorcery Starmetal from the list of UB ores.
- Make UB ores drop the ore they are based on when Silk Touched instead of their actual raw ore.