### PR TITLE
Totemic Stripped Logs Fixes

### DIFF
--- a/overrides/config/jei/itemBlacklist.cfg
+++ b/overrides/config/jei/itemBlacklist.cfg
@@ -983,12 +983,17 @@ advanced {
         extracells:pattern.fluid:sulphuricacid;m=0
         appliedenergistics2:facade:{damage:4,item:"undergroundbiomes:sedimentary_stone_astralsorcery_blockcustomore"}
         appliedenergistics2:facade:{damage:5,item:"undergroundbiomes:sedimentary_stone_astralsorcery_blockcustomsandore_1"}
+        totemic:wooden_pillar:3
         appliedenergistics2:facade:{damage:5,item:"undergroundbiomes:sedimentary_stone_immersiveengineering_ore_5"}
+        totemic:wooden_pillar:5
         extracells:pattern.fluid:knightslime;m=0
         thermalexpansion:morb:divinerpg:skythern_fiend
+        totemic:wooden_pillar:1
         appliedenergistics2:facade:{damage:9,item:"reccomplex:generic_solid"}
+        totemic:wooden_pillar:7
         enderio:item_soul_vial:Evolved Enderman
         contenttweaker:puzzle_tile_rkrbk
+        totemic:wooden_pillar:9
         mysticalagriculture:osmium_crop
         appliedenergistics2:facade:{damage:14,item:"chisel:dirt"}
         enderio:item_broken_spawner:Reyvor
@@ -1956,6 +1961,7 @@ advanced {
         appliedenergistics2:facade:{damage:3,item:"chisel:limestone2"}
         appliedenergistics2:facade:{damage:4,item:"chisel:blockplatinum"}
         appliedenergistics2:facade:{damage:0,item:"atum:linen_orange"}
+        totemic:wooden_pillar:11
         appliedenergistics2:facade:{damage:2,item:"twilightforest:castle_pillar"}
         appliedenergistics2:facade:{damage:6,item:"ebwizardry:crystal_block"}
         enderio:item_broken_spawner:Slimeling
@@ -2108,6 +2114,7 @@ advanced {
         appliedenergistics2:facade:{damage:0,item:"chisel:hardenedclay"}
         enderio:item_broken_spawner:Moose
         appliedenergistics2:facade:{damage:1,item:"undergroundbiomes:sedimentary_stone_rftools_dimensional_shard_ore"}
+        totemic:wooden_pillar_base:11
         enderio:item_soul_vial:Towerwood Borer
         appliedenergistics2:facade:{damage:9,item:"chisel:tyrian"}
         appliedenergistics2:facade:{damage:5,item:"ebwizardry:crystal_block"}
@@ -3273,7 +3280,12 @@ advanced {
         enderio:item_soul_vial:Bald Eagle
         appliedenergistics2:facade:{damage:14,item:"actuallyadditions:block_colored_lamp_on"}
         enderio:item_soul_vial:Adherent [NYI]
+        totemic:wooden_pillar_base:1
         appliedenergistics2:facade:{damage:1,item:"undergroundbiomes:igneous_stone_evilcraft_dark_ore"}
+        totemic:wooden_pillar_base:3
+        totemic:wooden_pillar_base:5
+        totemic:wooden_pillar_base:7
+        totemic:wooden_pillar_base:9
         enderio:item_soul_vial:Smelter
         appliedenergistics2:facade:{damage:0,item:"minecraft:emerald_block"}
         appliedenergistics2:facade:{damage:7,item:"undergroundbiomes:sedimentary_stone_immersiveengineering_ore"}

--- a/overrides/scripts/ActivateBlockJEI.zs
+++ b/overrides/scripts/ActivateBlockJEI.zs
@@ -50,6 +50,9 @@ addInteraction(<minecraft:dye:15>, <minecraft:double_plant:1>, <minecraft:double
 addInteraction(<minecraft:dye:15>, <minecraft:double_plant:4>, <minecraft:double_plant:4> * 2);
 addInteraction(<minecraft:dye:15>, <minecraft:double_plant:5>, <minecraft:double_plant:5> * 2);
 
+// Totemic Stripping Red Cedar Logs
+addInteraction(<totemic:bark_stripper>, <totemic:cedar_log>, <totemic:stripped_cedar_log>);
+
 // Basic Salis Mundus tranformations
 addInteraction(<thaumcraft:salis_mundus>, <minecraft:bookshelf>, <thaumcraft:thaumonomicon>);
 addInteraction(<thaumcraft:salis_mundus>, <extendedcrafting:ender_crafter>, <thaumcraft:arcane_workbench>.withTag({display:{Lore:["§r§bMust be unlocked in the Thaumonomicon."]}}));

--- a/overrides/scripts/Totemic.zs
+++ b/overrides/scripts/Totemic.zs
@@ -5,6 +5,10 @@ print("STARTING Totemic.zs");
 recipes.remove(<totemic:totem_whittling_knife>);
 recipes.addShaped(<totemic:totem_whittling_knife>, [[null,<contenttweaker:compressed_obsidian2>,<ore:blockIron>],[null,<ore:blockCopper>,<ore:logWood>],[<ore:blockCopper>,<ore:logWood>,null]]);
 
+# Stripped Red Cedar Pillar & Base
+recipes.addShaped(<totemic:wooden_pillar:13> * 6, [[null,<totemic:stripped_cedar_log>,null],[<totemic:totem_whittling_knife>.anyDamage().transformDamage(1),<totemic:stripped_cedar_log>,null],[null,<totemic:stripped_cedar_log>,null]]);
+recipes.addShaped(<totemic:wooden_pillar_base:13> * 6, [[null,<totemic:stripped_cedar_log>,null],[<totemic:totem_whittling_knife>.anyDamage().transformDamage(1),<totemic:stripped_cedar_log>,null],[<totemic:stripped_cedar_log>,<totemic:stripped_cedar_log>,<totemic:stripped_cedar_log>]]);
+
 # Totemist Drum
 recipes.remove(<totemic:drum>);
 recipes.addShaped(<totemic:drum>, [[<contenttweaker:treated_leather>,<contenttweaker:treated_leather>,<contenttweaker:treated_leather>],[<ore:logWood>,<ore:blockCopper>,<ore:logWood>],[null,<ore:logWood>,null]]);


### PR DESCRIPTION
resolve #899
- Hid all but Stripped Red Cedar Logs & variants from JEI, as the others were unobtainable.
- Add an Activate Block Interaction to JEI for the Bark Stripper converted Red Cedar Logs into Stripped Red Cedar Logs.
- Add crafting recipes for Stripped Red Cedar Pillars and Stripped Red Cedar Pillar Bases.