### PR TITLE
stop natura generating stuff in wrong dimensions

### DIFF
--- a/overrides/config/natura.cfg
+++ b/overrides/config/natura.cfg
@@ -99,8 +99,70 @@ worldgen {
     I:"Maloberry Spawn Rarity"=40
     I:"Maple Tree Spawn Rarity"=10
     I:"Nether World Generation Dimension Blacklist" <
+        0
+        1
+        50
+        51
+        52
+        53
+        7
+        420
+        421
+        422
+        423
+        424
+        425
+        426
+        427
+        66
+        -11325
+        -9999
+        428
+        -100
+        14676
+        4
+        -27
+        -26
+        -9
+        -11
+        17
+        -30
+        -29
+        -31
+        -28
      >
     I:"Overworld World Generation Dimension Blacklist" <
+        -1
+        1
+        50
+        51
+        52
+        53
+        7
+        420
+        421
+        422
+        423
+        424
+        425
+        426
+        427
+        66
+        -11325
+        -9999
+        428
+        -100
+        14676
+        4
+        -27
+        -26
+        -9
+        -11
+        17
+        -30
+        -29
+        -31
+        -28
      >
     I:"Raspberry Spawn Range"=64
     I:"Raspberry Spawn Rarity"=30


### PR DESCRIPTION
it was always just this simple. now, no more random natura stuff in dimensions where it shouldnt spawn (eg dreadlands)