### PR TITLE
Fix ProjectRed electrotine showing in JEI

### DIFF
--- a/overrides/config/jei/itemBlacklist.cfg
+++ b/overrides/config/jei/itemBlacklist.cfg
@@ -8342,6 +8342,7 @@ advanced {
         projectred-core:resource_item:101
         projectred-core:resource_item:102
         projectred-core:resource_item:100
+        projectred-core:resource_item:105
         appliedenergistics2:facade:{damage:6,item:"undergroundbiomes:igneous_stone_immersiveengineering_ore_4"}
         appliedenergistics2:facade:{damage:0,item:"atum:ceramic_orange"}
         appliedenergistics2:facade:{damage:10,item:"botania:biomestoneb"}

--- a/overrides/scripts/ProjectRedCore.zs
+++ b/overrides/scripts/ProjectRedCore.zs
@@ -38,14 +38,15 @@ mods.immersiveengineering.ArcFurnace.removeRecipe(<projectred-core:resource_item
 mods.immersiveengineering.ArcFurnace.addRecipe(<projectred-core:resource_item:103>, <projectred-core:resource_item:251>, null,  200, 128);
 
 # Using a custom Electrotine item, because CraftTweaker Block Drops can't recognize mod names with a dash, like 'projectred-core'
-# Removing Electrotine (rest is in ContentTweakerRecipes.zs under # Electrotine)
-recipes.remove(<projectred-core:resource_item:105>);
+# Removing and Hiding Electrotine (rest is in ContentTweakerRecipes.zs under # Electrotine)
+mods.jei.JEI.removeAndHide(<projectred-core:resource_item:105>);
 
 # Electrotine Ore Processing (has to be lower priority than the item's creation)
 # Removals
 mods.thermalexpansion.Pulverizer.removeRecipe(<contenttweaker:electrotine_ore>);
 mods.actuallyadditions.Crusher.removeRecipe(<contenttweaker:electrotine>);
 mods.astralsorcery.Grindstone.removeRecipe(<contenttweaker:electrotine>);
+
 # Additions
 recipes.addShapeless(<contenttweaker:electrotine> * 4, [<contenttweaker:electrotine_ore>, <ore:dustPetrotheum>]);
 IECrusher.addRecipe(<contenttweaker:electrotine> * 4, <contenttweaker:electrotine_ore>, 4000);

--- a/overrides/scripts/ProjectRedCore.zs
+++ b/overrides/scripts/ProjectRedCore.zs
@@ -38,8 +38,8 @@ mods.immersiveengineering.ArcFurnace.removeRecipe(<projectred-core:resource_item
 mods.immersiveengineering.ArcFurnace.addRecipe(<projectred-core:resource_item:103>, <projectred-core:resource_item:251>, null,  200, 128);
 
 # Using a custom Electrotine item, because CraftTweaker Block Drops can't recognize mod names with a dash, like 'projectred-core'
-# Removing and Hiding Electrotine (rest is in ContentTweakerRecipes.zs under # Electrotine)
-mods.jei.JEI.removeAndHide(<projectred-core:resource_item:105>);
+# Removing Electrotine (rest is in ContentTweakerRecipes.zs under # Electrotine)
+recipes.remove(<projectred-core:resource_item:105>);
 
 # Electrotine Ore Processing (has to be lower priority than the item's creation)
 # Removals


### PR DESCRIPTION
The projectred electrotine still shows in the EMC tablet, but at least it’s removed from JEI 