### PR TITLE
Remove nether inferium/prosperity ore in AE2 grindstone recipe

### DIFF
--- a/overrides/scripts/OreProcessingAdditions.zs
+++ b/overrides/scripts/OreProcessingAdditions.zs
@@ -549,6 +549,7 @@ mods.astralsorcery.Grindstone.addRecipe(<mysticalagriculture:prosperity_ore>, <m
 # Nether Prosperity Ore
 recipes.addShapeless(<mysticalagriculture:crafting:5> * 5, [<mysticalagriculture:nether_prosperity_ore>,<ore:dustPetrotheum>]);
 mods.astralsorcery.StarlightInfusion.addInfusion(<mysticalagriculture:nether_prosperity_ore>, <mysticalagriculture:crafting:5> * 6, false, 1, 200);
+Grinder.removeRecipe(<mysticalagriculture:nether_prosperity_ore>);
 
 # End Prosperity Ore
 recipes.addShapeless(<mysticalagriculture:crafting:5> * 5, [<mysticalagriculture:end_prosperity_ore>,<ore:dustPetrotheum>]);
@@ -577,6 +578,7 @@ mods.astralsorcery.Grindstone.addRecipe(<mysticalagriculture:inferium_ore>, <mys
 # Nether Inferium Ore
 recipes.addShapeless(<mysticalagriculture:crafting> * 5, [<mysticalagriculture:nether_inferium_ore>,<ore:dustPetrotheum>]);
 mods.astralsorcery.StarlightInfusion.addInfusion(<mysticalagriculture:nether_inferium_ore>, <mysticalagriculture:crafting> * 6, false, 1, 200);
+Grinder.removeRecipe(<mysticalagriculture:nether_inferium_ore>);
 
 # End Inferium Ore
 recipes.addShapeless(<mysticalagriculture:crafting> * 5, [<mysticalagriculture:end_inferium_ore>,<ore:dustPetrotheum>]);


### PR DESCRIPTION
Found this by accident. Only the nether versions of Prosperity and Inferium Ore have processing recipes in the AE2 grindstone. I opted to remove these recipes because the recipes for the overworld and end variations don't exist to begin with and because the AE2 grindstone is useless anyway. If you want me to add the recipes for the overworld and end variations of the ores instead, let me know.