### PR TITLE
Maintain May 2023

### DIFF
--- a/overrides/config/astralsorcery.cfg
+++ b/overrides/config/astralsorcery.cfg
@@ -168,7 +168,7 @@ data_persistence {
 
 entities {
     # Defines how common ***ambient*** flares are. the lower the more common. 0 = ambient ones don't appear/disabled. [range: 0 ~ 200000, default: 9]
-    I:EntityFlare.ambientspawn=9
+    I:EntityFlare.ambientspawn=0
 
     # If this is set to true, occasionally, a spawned flare will (attempt to) kill bats close to it. [default: true]
     B:EntityFlare.killbats=true

--- a/overrides/config/modularmachinery/recipes/mob_loot_fabricator_box.json
+++ b/overrides/config/modularmachinery/recipes/mob_loot_fabricator_box.json
@@ -1,0 +1,29 @@
+{
+    "machine": "mob_loot_fabricator",
+    "registryName": "mob_loot_fabricator_box",
+    "recipeTime": 20,
+    "requirements": [
+        {
+            "type": "item",
+            "io-type": "input",
+            "item": "evilcraft:box_of_eternal_closure",
+            "nbt": {
+                "spiritTag": {
+                    "innerEntity": "net.minecraft.entity.monster.EntityEnderman"
+                }
+            },
+            "amount": 1,
+            "chance": 0
+        },
+        {
+            "type": "lifeessence",
+            "io-type": "input",
+            "essenceamount": 3000
+        },
+        {
+            "type": "item",
+            "io-type": "output",
+            "item": "extendedcrafting:material@37"
+        }
+    ]
+}

--- a/overrides/scripts/BloodMagic.zs
+++ b/overrides/scripts/BloodMagic.zs
@@ -550,6 +550,33 @@ recipes.addShaped(<bloodmagic:decorative_brick:3> * 4, [[<bloodmagic:decorative_
 <bloodmagic:blood_shard>.addTooltip(format.white("to obtain. Be wary though. While it's active,"));
 <bloodmagic:blood_shard>.addTooltip(format.white("it constantly drains LP from your Life Network!"));
 
+# Tartaric Gem
+recipes.remove(<bloodmagic:soul_gem:4>);
+function addSoulGemConversion(gem as IItemStack, converter as IItemStack, target as string) {
+    val base = target == "";
+    recipes.addShapeless(gem.name + target, base ? gem : gem.withTag({demonWillType:target}), [gem.marked("gem"), converter],
+        function(out, ins, cInfo) {
+            val newSouls = isNull(ins.gem.tag.souls) ? 0 : ins.gem.tag.souls;
+            return base ? ins.gem.withTag({souls:newSouls}) : ins.gem.withTag({demonWillType:target,souls:newSouls});
+        },
+        null
+    );
+}
+
+for gem in [
+    <bloodmagic:soul_gem:0>,
+    <bloodmagic:soul_gem:1>,
+    <bloodmagic:soul_gem:2>,
+    <bloodmagic:soul_gem:3>,
+    <bloodmagic:soul_gem:4>
+] as IItemStack[] {
+    addSoulGemConversion(gem, <bloodmagic:item_demon_crystal>, "");
+    addSoulGemConversion(gem, <bloodmagic:item_demon_crystal:1>, "corrosive");
+    addSoulGemConversion(gem, <bloodmagic:item_demon_crystal:2>, "destructive");
+    addSoulGemConversion(gem, <bloodmagic:item_demon_crystal:3>, "vengeful");
+    addSoulGemConversion(gem, <bloodmagic:item_demon_crystal:4>, "steadfast");
+}
+
 # Tartaric Gem tooltips
 <bloodmagic:soul_gem:0>.addTooltip(format.white("This Tartaric Gem can store a maximum of ") + format.red("64") + format.white(" Will Quality."));
 <bloodmagic:soul_gem:1>.addTooltip(format.white("This Tartaric Gem can store a maximum of ") + format.red("256") + format.white(" Will Quality."));

--- a/overrides/scripts/ContentTweakerRecipes.zs
+++ b/overrides/scripts/ContentTweakerRecipes.zs
@@ -1508,7 +1508,7 @@ mods.extendedcrafting.CombinationCrafting.addRecipe(<contenttweaker:dusty_therma
 mods.extendedcrafting.CombinationCrafting.addRecipe(<contenttweaker:botanic_singularity>, 400000, 10000, <contenttweaker:empty_core>, [<extendedcrafting:singularity_custom:147>,<extendedcrafting:singularity_custom:148>,<extendedcrafting:singularity_custom:149>]);
 
 # Thaumic Singularity
-mods.extendedcrafting.CombinationCrafting.addRecipe(<contenttweaker:thaumic_singularity>, 400000, 10000, <contenttweaker:empty_core>, [<extendedcrafting:singularity_custom:158>,<extendedcrafting:singularity_custom:157>,<extendedcrafting:singularity:21>,<extendedcrafting:singularity_custom:150>,<extendedcrafting:singularity_custom:152>]);
+mods.extendedcrafting.CombinationCrafting.addRecipe(<contenttweaker:thaumic_singularity>, 400000, 10000, <contenttweaker:empty_core>, [<extendedcrafting:singularity_custom:158>,<extendedcrafting:singularity_custom:157>,<extendedcrafting:singularity:21>,<extendedcrafting:singularity_custom:150>,<extendedcrafting:singularity_custom:151>,<extendedcrafting:singularity_custom:152>]);
 
 # Alchemical Singularity
 mods.extendedcrafting.CombinationCrafting.addRecipe(<contenttweaker:alchemic_singularity>, 400000, 10000, <contenttweaker:empty_core>, [<extendedcrafting:singularity:20>,<extendedcrafting:singularity_custom:33>,<extendedcrafting:singularity:32>,<extendedcrafting:singularity:30>]);

--- a/overrides/scripts/DivineRPG.zs
+++ b/overrides/scripts/DivineRPG.zs
@@ -59,7 +59,7 @@ recipes.addShaped(<divinerpg:horde_horn>, [[<thermalfoundation:storage:7>,<actua
 
 # Angelic Chestplate
 recipes.remove(<divinerpg:angelic_chestplate>);
-recipes.addShaped(<divinerpg:angelic_chestplate>, [[<divinerpg:bluefire_stone>,<extrautils2:angelring:*>,<divinerpg:bluefire_stone>],[<divinerpg:ice_stone>,<divinerpg:bluefire_stone>,<divinerpg:ice_stone>],[<divinerpg:ice_stone>,<divinerpg:ice_stone>,<divinerpg:ice_stone>]]);
+recipes.addShaped(<divinerpg:angelic_chestplate>, [[<divinerpg:bluefire_stone>,null,<divinerpg:bluefire_stone>],[<divinerpg:ice_stone>,<contenttweaker:block_of_elevation>,<divinerpg:ice_stone>],[<divinerpg:ice_stone>,<divinerpg:ice_stone>,<divinerpg:ice_stone>]]);
 
 # Divine Rock
 recipes.remove(<divinerpg:divine_rock>);

--- a/overrides/scripts/Events.zs
+++ b/overrides/scripts/Events.zs
@@ -160,17 +160,26 @@ function removeItemFromHand(player as IPlayer, item as IItemStack) {
 }
 
 events.onPlayerInteractBlock(function(e as PlayerInteractBlockEvent) {
+
+    val blockID = e.block.definition.id;
+
+    // Prevents the Matter Transporter from duping IF Black Hole stuff.
+    if (whatHand(e.player, <quantumflux:mattertransporter>) != crafttweaker.entity.IEntityEquipmentSlot.head() &&
+        (blockID == <industrialforegoing:black_hole_unit>.definition.id || blockID == <industrialforegoing:black_hole_tank>.definition.id)) {
+        e.cancel();
+    }
+
     if (e.player.world.isRemote()) {
         return;
     }
 
     // The Uncrafting Table should never be openable, to prevent a duplication bug
-    if (e.block.definition.id == <twilightforest:uncrafting_table>.definition.id) {
+    if (blockID == <twilightforest:uncrafting_table>.definition.id) {
         e.cancel();
     }
 
     // Grant the user the Astral Sorcery Knowledge to use the table they just right clicked on.
-    if (e.block.definition.id == <astralsorcery:blockaltar>.definition.id) {
+    if (blockID == <astralsorcery:blockaltar>.definition.id) {
         progressAstral(e.player, e.block.meta);
     }
 
@@ -183,7 +192,7 @@ events.onPlayerInteractBlock(function(e as PlayerInteractBlockEvent) {
     }
 
     // Activate the held ender core if the target block was a stabilized end crystal
-    if (e.block.definition.id == <contenttweaker:stabilized_end_crystal>.definition.id) {
+    if (blockID == <contenttweaker:stabilized_end_crystal>.definition.id) {
         activateEnderCore(e.player);
     }
 

--- a/overrides/scripts/Excavator.zs
+++ b/overrides/scripts/Excavator.zs
@@ -320,6 +320,7 @@ addExcavator("Cassiterite", 15, ["oreTin"], [1.0], [0, 9, -11325]);
 addExcavator("Gold", 20, ["oreGold", "oreCopper", "oreNickel"], [0.65, 0.25, 0.1], [0, 9, -11325]);
 addExcavator("Nickel", 20, ["oreNickel", "oreIron"], [0.85, 0.15], [0, 9, -11325]);
 addExcavator("Yellorium", 10, ["oreYellorium"], [1.0], [0, 9, -11325]);
+addExcavator("Certus Quartz", 15, ["oreCertusQuartz", "oreChargedCertusQuartz", "oreQuartzBlack"], [0.6, 0.1, 0.3], [0, 9, -11325]);
 addExcavator("Quartzite", 5, ["oreOverworldQuartz", "oreCertusQuartz", "oreChargedCertusQuartz", "oreQuartzBlack"], [0.5, 0.35, 0.05, 0.1], [0, 9, -11325]);
 addExcavator("Galena", 15, ["oreLead", "oreSilver"], [0.50, 0.50], [0, 9, -11325]);
 addExcavator("Lapis", 10, ["oreLapis", "oreIron", "dustSulfur"], [0.65, 0.3, 0.05], [0, 9, -11325]);

--- a/overrides/scripts/MinecraftRecipes.zs
+++ b/overrides/scripts/MinecraftRecipes.zs
@@ -190,7 +190,6 @@ mods.mekanism.crusher.removeRecipe(<minecraft:gunpowder>);
 <minecraft:dragon_breath>.addTooltip(format.gray("Ender Air Bottles") + format.white(", try the following: Do ") + format.red("NOT") + format.white(" Right Click on blocks,"));
 <minecraft:dragon_breath>.addTooltip(format.white("instead, angle your clicks so you only reach the purple ") + format.lightPurple("Dragon's"));
 <minecraft:dragon_breath>.addTooltip(format.lightPurple("Breath particles") + format.white(", and ") + format.red("NOT") + format.white(" the blocks below."));
-recipes.addShaped(<minecraft:dragon_breath>, [[<mysticalagradditions:dragon_egg_essence>,<mysticalagradditions:dragon_egg_essence>,<mysticalagradditions:dragon_egg_essence>],[<mysticalagradditions:dragon_egg_essence>,<minecraft:glass_bottle>,<mysticalagradditions:dragon_egg_essence>],[<mysticalagradditions:dragon_egg_essence>,<mysticalagradditions:dragon_egg_essence>,<mysticalagradditions:dragon_egg_essence>]]);
 
 # Additional Wither Skeleton Skull recipe
 recipes.addShaped(<minecraft:skull:1>, [[<quark:black_ash>,<quark:black_ash>,<quark:black_ash>],[<quark:black_ash>,<minecraft:skull>,<quark:black_ash>],[<quark:black_ash>,<quark:black_ash>,<quark:black_ash>]]);

--- a/overrides/scripts/MysticalAgriculture.zs
+++ b/overrides/scripts/MysticalAgriculture.zs
@@ -1290,6 +1290,12 @@ recipes.addShaped(<alchemistry:ingot:24> * 3, [[<mysticalagriculture:chrome_esse
 # Rock Crystal Seeds
 # recipe in config/modularmachinery/recipes/weak_fusion_plant_mysticalagriculture_rock_crystal_seeds.json
 
+# Ender Air
+recipes.addShaped(<botania:manaresource:15>, [[<mysticalagriculture:end_essence>,<mysticalagriculture:end_essence>,<mysticalagriculture:end_essence>],[<mysticalagriculture:end_essence>,<minecraft:glass_bottle>,<mysticalagriculture:end_essence>],[<mysticalagriculture:end_essence>,<mysticalagriculture:end_essence>,<mysticalagriculture:end_essence>]]);
+
+# Dragon's Breath
+recipes.addShaped(<minecraft:dragon_breath>, [[<mysticalagradditions:dragon_egg_essence>,<mysticalagradditions:dragon_egg_essence>,<mysticalagradditions:dragon_egg_essence>],[<mysticalagradditions:dragon_egg_essence>,<botania:manaresource:15>,<mysticalagradditions:dragon_egg_essence>],[<mysticalagradditions:dragon_egg_essence>,<mysticalagradditions:dragon_egg_essence>,<mysticalagradditions:dragon_egg_essence>]]);
+
 # Ores from Essence
 function addMysticalAgricultureEssenceToOreRecipe(ore as IItemStack, essence as IItemStack, amount as int) {
 	recipes.addShaped(ore * amount, [[essence,essence,essence],[essence,<ore:stone>,essence],[essence,essence,essence]]);

--- a/overrides/scripts/Roots.zs
+++ b/overrides/scripts/Roots.zs
@@ -5,6 +5,7 @@ import mods.roots.Mortar;
 import mods.roots.Fey;
 import mods.roots.Rituals;
 import mods.roots.RunicShears;
+import mods.roots.AnimalHarvest;
 import mods.roots.SummonCreatures;
 import mods.roots.Modifiers;
 import crafttweaker.formatting.IFormattedText;
@@ -281,6 +282,12 @@ Rituals.modifyRitual("ritual_gathering", [<roots:wildewheet>, <roots:cloud_berry
 
 # Summon Creatures Ritual
 SummonCreatures.clearLifeEssence();
+
+# Animal Harvest Ritual
+AnimalHarvest.addEntity(<entity:natura:imp>);
+AnimalHarvest.addEntity(<entity:totemic:buffalo>);
+AnimalHarvest.addEntity(<entity:totemic:bald_eagle>);
+AnimalHarvest.addEntity(<entity:thaumcraft:wisp>);
 
 # Artificial Scarab Wings
 Fey.addRecipe("artificial_scarab_wings", <contenttweaker:artificial_scarab_wings>, [<roots:moonglow_leaf>,<roots:wildewheet>,<roots:stalicripe>,<roots:fey_leather>,<roots:spirit_herb>]);

--- a/overrides/scripts/Roots.zs
+++ b/overrides/scripts/Roots.zs
@@ -281,7 +281,6 @@ Rituals.modifyRitual("ritual_gathering", [<roots:wildewheet>, <roots:cloud_berry
 
 # Summon Creatures Ritual
 SummonCreatures.clearLifeEssence();
-<natura:materials:6>.addTooltip(format.white("Imps can be spawned by the Roots 'Summon Creatures' ritual."));
 
 # Artificial Scarab Wings
 Fey.addRecipe("artificial_scarab_wings", <contenttweaker:artificial_scarab_wings>, [<roots:moonglow_leaf>,<roots:wildewheet>,<roots:stalicripe>,<roots:fey_leather>,<roots:spirit_herb>]);

--- a/overrides/scripts/Roots.zs
+++ b/overrides/scripts/Roots.zs
@@ -67,7 +67,7 @@ Fey.addRecipe("apothecary_pouch", <roots:apothecary_pouch>, [<roots:component_po
 <roots:apothecary_pouch>.addTooltip(format.bold(format.red("WARNING: ") + format.gray("Crafting this item will wipe the input bag's inventory!")));
 
 # Grove Supplication Ritual
-Rituals.modifyRitual("grove_supplication", [<ore:mossyCobblestone>,<totemic:cedar_sapling>,<totemic:eagle_drops:1>,<contenttweaker:root_of_the_fallen>,<roots:petals>]);
+Rituals.modifyRitual("grove_supplication", [<ore:blockMossy>,<totemic:cedar_sapling>,<totemic:eagle_drops:1>,<contenttweaker:root_of_the_fallen>,<roots:petals>]);
 
 # Dewgonia
 Pyre.removeRecipe(<roots:dewgonia>);

--- a/overrides/scripts/Roots.zs
+++ b/overrides/scripts/Roots.zs
@@ -67,7 +67,7 @@ Fey.addRecipe("apothecary_pouch", <roots:apothecary_pouch>, [<roots:component_po
 <roots:apothecary_pouch>.addTooltip(format.bold(format.red("WARNING: ") + format.gray("Crafting this item will wipe the input bag's inventory!")));
 
 # Grove Supplication Ritual
-Rituals.modifyRitual("grove_supplication", [<minecraft:mossy_cobblestone>,<totemic:cedar_sapling>,<totemic:eagle_drops:1>,<contenttweaker:root_of_the_fallen>,<roots:petals>]);
+Rituals.modifyRitual("grove_supplication", [<ore:mossyCobblestone>,<totemic:cedar_sapling>,<totemic:eagle_drops:1>,<contenttweaker:root_of_the_fallen>,<roots:petals>]);
 
 # Dewgonia
 Pyre.removeRecipe(<roots:dewgonia>);


### PR DESCRIPTION
resolves #977
has a number of smaller changes

- Add conversion recipes for each soul gem tier (instead of just the final tier) that also copy will quantity instead of resetting.
- Adjust Angelic Chestplate recipe to cost Elevatium instead of an Angel Ring.
- Add a Mystical Agriculture recipe for Ender Air.
- Make the Mystical Agriculture recipe for Dragon's Breath use Ender Air.
- Add a Mob Loot Fabricator recipe for Extended Crafting Ender Nuggets.
- Add a quest describing Botania Lenses and how mana transfer works.
- Prevent the Matter Transporter picking up a Black Hole Tank/Unit.
- Remove a duplicate tooltip for Imp Leather.
- Add a few more animals - Imps, Buffalo, Eagles, and Wisps - to Root's Animal Harvest Ritual.
- Allow use of any Mossy Cobblestone in the Roots Grove Supplication Ritual.
- Disable Astral Sorcery flares to prevent laggy entity buildup due to automation.
- Add missing recipe using Void Metal Singularity
- Add a Certus Quartz Excavator vein at Uncommon rarity (3x as common as Quartzite)

