### PR TITLE
Adds recipe to make 9 Shattered Mystical Iron Crystals from 1 Mystical Iron Block when dropped as entity

### DIFF
--- a/overrides/scripts/ModSpecific/ContentTweakerRecipes.zs
+++ b/overrides/scripts/ModSpecific/ContentTweakerRecipes.zs
@@ -1185,6 +1185,7 @@ recipes.addShapeless(<contenttweaker:eye_of_the_nightmare>, [<minecraft:ender_pe
 
 // Shattered Mystical Iron Crystal
 ExplosionCrafting.explodeItemRecipe(<contenttweaker:shattered_mystical_iron_crystal>, <contenttweaker:mystical_iron_ingot>);
+ExplosionCrafting.explodeItemRecipe(<contenttweaker:shattered_mystical_iron_crystal> * 9, <contenttweaker:mystical_iron_block>);
 ExplosionCrafting.explodeBlockRecipe(<contenttweaker:shattered_mystical_iron_crystal> * 9, <contenttweaker:mystical_iron_block>);
 
 // Growth Infusion Liquid


### PR DESCRIPTION
Resolves #1049 by adding a recipe to make 9 Shattered Mystical Iron Crystals from 1 Mystical Iron Block when dropped as entity