### PR TITLE
Update DJ2Addons 1.2.1.1.1 -> 1.3.0-BETA

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1410,7 +1410,7 @@
     {
       "slug": "divine-journey-2-addons",
       "projectID": 605280,
-      "fileID": 4069565,
+      "fileID": 5275352,
       "required": true
     },
     {

--- a/overrides/scripts/ModSpecific/Botania.zs
+++ b/overrides/scripts/ModSpecific/Botania.zs
@@ -939,16 +939,21 @@ Brews.addBrewRecipe(
     [<minecraft:nether_wart>, <totemic:cooked_buffalo_meat>, <contenttweaker:chicken_nugget>, <contenttweaker:burger>, <contenttweaker:taco>]
 );
 
-// Warp Ward Brew
-mods.botania.Brew.removeRecipe("warpWard");
-Brews.addBrewRecipe(
-    Brews.makeBrew(
-        "thaumcraft:warpward",
-        "Sane Thoughts",
-        100000,
-        16503291,
-        <potion:thaumcraft:warpward>.makePotionEffect(20 * 60 * 60 * 2, 0) // brew will last an hour
-    ),
+// Warp Ward Brew Recipes
+val warpWardBrew as Brew = Brews.getBrew("botania.brews.warpWard");
+Brews.removeRecipe("botania.brews.warpWard");
+
+// Add old recipe back for the bottles and incense stick
+Brews.addOutputRestrictedBrewRecipe(
+    warpWardBrew,
+    [<botania:vial:0>, <botania:vial:1>, <botania:incensestick>],
+    [<minecraft:nether_wart>, <thaumcraft:salis_mundus>, <thaumcraft:amber>, <thaumcraft:bath_salts>, <thaumcraft:sanity_soap>]
+);
+
+// Add special recipe for the pendant
+Brews.addOutputRestrictedBrewRecipe(
+    warpWardBrew,
+    [<botania:bloodpendant>],
     [<minecraft:nether_wart>, <thaumcraft:salis_mundus>, <thaumcraft:bath_salts>, <thaumcraft:sanity_soap>, <contenttweaker:conducted_impetus>, <thaumcraft:sanity_checker>]
 );
 

--- a/overrides/scripts/ModSpecific/ExtraUtilities2.zs
+++ b/overrides/scripts/ModSpecific/ExtraUtilities2.zs
@@ -8,8 +8,21 @@ import mods.immersiveengineering.MetalPress;
 import mods.tconstruct.Melting;
 import mods.astralsorcery.Altar;
 import mods.inworldcrafting.FluidToItem;
+import dj2addons.extrautils2.BiomeMarker;
 
 print("STARTING ExtraUtilities2.zs");
+
+// Blacklist Atum biomes in the Quantum Quarry
+BiomeMarker.excludeBiome(<biome:atum:limestone_crags>);
+BiomeMarker.excludeBiome(<biome:atum:dead_oasis>);
+BiomeMarker.excludeBiome(<biome:atum:deadwood_forest>);
+BiomeMarker.excludeBiome(<biome:atum:dried_river>);
+BiomeMarker.excludeBiome(<biome:atum:limestone_crags>);
+BiomeMarker.excludeBiome(<biome:atum:limestone_mountains>);
+BiomeMarker.excludeBiome(<biome:atum:oasis>);
+BiomeMarker.excludeBiome(<biome:atum:sand_dunes>);
+BiomeMarker.excludeBiome(<biome:atum:sand_hills>);
+BiomeMarker.excludeBiome(<biome:atum:sand_plains>>);
 
 // Snow Globe
 recipes.remove(<extrautils2:snowglobe>);


### PR DESCRIPTION
### Configs:
* Botania: Made the harder warp ward recipe only applicable for the pendant and restored the original recipe for the other containers.
* Extra Utilities: Blacklisted Atum biomes in the Quantum Quarry.
* Thaumcraft: Created config for adding blocks as infusion stabilizers. (Still needs to be filled in.)


Mod changelog:

> ### Internal Changes:
> 
> *   Now requires MixinBooter 7.0. (already included in DJ2 1.20 and up)
> *   Migrated several implementations to MixinExtras so other mods can rewrite them if desired. (...which probably won't happen, but it's a nice thing to allow regardless.)
> *   Opened up the Java part of the CraftTweaker API.  See btpos.dj2addons.api in the Javadoc.
> 
> ### Optimizations:
> 
> * Actually Additions: Completely overhauled laser relay network handling, saving ~15% of client time for large bases and 1.5% of the total server time.
> * Aether: Stopped the accessories handler from destroying memory usage by creating a thousand objects per frame. (Only observed happening once, but now it'll never happen again.)
> * AgriCraft: Prevent Crop Sticks from checking neighbors for valid soil if they will never be spread to. (Saves another ~1.5% server time.)
> * EnderIO:
>   * Streamlined error handling, preventing debilitating lag if errors are constantly thrown.
>   * Cached regex pattern in EIO's profiler. (Saves ~0.5% server time.)
> 
> 
> 
> ### API:
> 
> * Botania: 
>   * Can now create __output-specific__ brew recipes, meaning different containers (vial, flask, pendant) can have different recipes. (See [docs](https://github.com/ByThePowerOfScience/DivineJourney2Addons/blob/f5a23b24f85770613d2ea124134a2b5c2ddcc835/docs/zs/dj2addons/botania/Brews.md))
>   * Remove brew recipes by key, allowing third-party brews to be removed.
>   * Get brews by name for use in and modification through CT scripts.
> * Bewitchment:
>   * Remove altar upgrades by item, block, or OreDict string.
> * Extra Utilities:
>   * Blacklist biomes from use in the Quantum Quarry, allowing pack devs to fix crashes from certain modded biomes, such as Atum biomes.
> * Mystical Agriculture:
>   * Add recipes to the Seed Reprocessor.
> * Thaumcraft:
>   * Add blocks as infusion stabilizers. (Note: this can't be done through CraftTweaker. See the docs [here](https://github.com/ByThePowerOfScience/DivineJourney2Addons/blob/f5a23b24f85770613d2ea124134a2b5c2ddcc835/docs/other/thaumcraft/InfusionStabilizers.md).)
> 
> ### Tweaks:
> * Extra Utilities:
>   * Made the Mechanical User copy the placer's Thaumcraft research, allowing vanilla Runic Matrix automation.
> 
> ### Patches:
> 
> * PackagedAuto:
>   * Now properly verifies NBT in recipes.
> * Immersive Engineering:
>   * Fixed client-side crashes with some multiblocks. (Thanks [C0D3-M4513R](https://github.com/ByThePowerOfScience/DivineJourney2Addons/pull/9/commits/07f0ce2cf561eb4996bf297216b57131ce1191f3)!)
> 