### PR TITLE
improve build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
 
       # Upload build artifacts to Curseforge
       - name: "Upload Client to Curseforge"
-        uses: itsmeow/curseforge-upload@v3
+        uses: itsmeow/curseforge-upload@v3.1.0
         id: client
         with:
           release_type: "${{ inputs.release-type }}"
@@ -140,7 +140,7 @@ jobs:
           # Will output "id", for the id of the project
 
       - name: "Upload Server to Curseforge"
-        uses: itsmeow/curseforge-upload@v3
+        uses: itsmeow/curseforge-upload@v3.1.0
         id: server
         with:
           release_type: "${{ inputs.release-type }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
 
       # Upload build artifacts to Github Releases
       - name: "Upload to GitHub Releases"
-        uses: "softprops/action-gh-release@v0.1.15"
+        uses: "softprops/action-gh-release@v2"
         with:
           name: Divine Journey ${{ inputs.version }}
           tag_name: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       # Create zip files for the Client and Server after downloading the required mods
       - name: "Build everything"
         id: build
-        run: python ./buildtools/build.py -CSDZ --key='${{ secrets.CFAPIKEY }}'
+        run: python ./buildtools/build.py -CSDZ -V='${{ inputs.version }}' --key='${{ secrets.CFAPIKEY }}'
         # Will output "client_name" and "server_name", for the name of the client and server zips
 
       # Commit changes after the build process

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,8 @@ jobs:
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "-----" >> $GITHUB_STEP_SUMMARY
-          echo "\*\*Divine Journey ${{ inputs.version }}\*\* is now available on" >> $GITHUB_STEP_SUMMARY
-          echo "\- Github: \<https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}>" >> $GITHUB_STEP_SUMMARY
-          echo "\- Curseforge: \<https://www.curseforge.com/minecraft/modpacks/divine-journey-2/files/${{ steps.client.outputs.id }}>" >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo "**Divine Journey ${{ inputs.version }}** is now available on" >> $GITHUB_STEP_SUMMARY
+          echo "- Github: <https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}>" >> $GITHUB_STEP_SUMMARY
+          echo "- Curseforge: <https://www.curseforge.com/minecraft/modpacks/divine-journey-2/files/${{ steps.client.outputs.id }}>" >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,10 @@ jobs:
         run: python ./buildtools/update_version.py -V='${{ inputs.version }}'
         # Will output "changelog", for the exact location of the changelog
 
+      - name: "Get server changelog"
+        id: server-changelog
+        run: echo "server_changelog=$(cat changelog/SERVER_UPDATE.md)" >> $GITHUB_OUTPUT
+
       # Create zip files for the Client and Server after downloading the required mods
       - name: "Build everything"
         id: build
@@ -147,7 +151,7 @@ jobs:
           parent_file_id: ${{ steps.client.outputs.id }}
           token: "${{ secrets.CF_PROJECT_KEY }}"
           changelog_type: markdown
-          changelog: changelog/SERVER_UPDATE.md
+          changelog: "${{ steps.server-changelog.outputs.server_changelog }}"
 
       - name: "Generate report"
         id: generate-report

--- a/buildtools/build.py
+++ b/buildtools/build.py
@@ -319,9 +319,10 @@ def getPreReleaseName() -> str:
     return ""
 
 
-def convertPackVersion(version: str):
+def convertPackVersion(location: str, version: str):
     """Convert the @PACK_VERSION@ placeholders into the actual pack version being used"""
-    for file in filesToUpdateVersion:
+    for target in filesToUpdateVersion:
+        file = f"{location}/{target}"
         f = open(file, "r")
         filedata = f.read()
         f.close()
@@ -484,12 +485,6 @@ def build(args):
         print("you must specify either client, server, or dev")
         return
 
-    # Get the modpack version from git tags if not an argument
-    version = getGitTagVersion() if args.version == None else args.version
-
-    # Converts the version locations of the pack to the version being released
-    convertPackVersion(version)
-
     # Read the manifest
     with open(f"{basePath}/manifest.json", "r") as file:
         manifest = json.load(file)
@@ -525,13 +520,18 @@ def build(args):
         forgeInstaller(manifest)
         print(f"installed the forge installer in {str(round(time() - start, 2))} seconds")
 
+    # Get the modpack version from git tags if not an argument
+    version = getGitTagVersion() if args.version == None else args.version
+
     # Copy required files to the client instance
     if (args.client):
         copyClient()
+        convertPackVersion(client, version)
 
     # Copy required files to the server instance
     if (args.server):
         copyServer(manifest)
+        convertPackVersion(server, version)
 
     if (args.zip):
         # Get the standard name of the pack

--- a/buildtools/build.py
+++ b/buildtools/build.py
@@ -104,6 +104,12 @@ symLinkDirs = [
     "scripts",
     "structures"
 ]
+# Files which contain a "@PACK_VERSION@" which must be replaced with the pack variable number
+filesToUpdateVersion = [
+    "manifest.json",
+    "overrides/config/CustomMainMenu/mainmenu.json",
+    "overrides/config/mputils/addons/mpbasic/mpbasic.cfg"
+]
 
 def print_argument_settings(args):
     """Prints what the build command will do"""
@@ -313,6 +319,19 @@ def getPreReleaseName() -> str:
     return ""
 
 
+def convertPackVersion(version: str):
+    """Convert the @PACK_VERSION@ placeholders into the actual pack version being used"""
+    for file in filesToUpdateVersion:
+        f = open(file, "r")
+        filedata = f.read()
+        f.close()
+
+        newdata = filedata.replace("@PACK_VERSION@", version)
+
+        with open(file, 'w') as new:
+            new.write(newdata)
+
+
 def getForgeVersion(manifest):
     """Get the Forge version"""
     forgeVer = manifest["minecraft"]["modLoaders"][0]["id"].split("-")[-1]
@@ -467,6 +486,9 @@ def build(args):
 
     # Get the modpack version from git tags if not an argument
     version = getGitTagVersion() if args.version == None else args.version
+
+    # Converts the version locations of the pack to the version being released
+    convertPackVersion(version)
 
     # Read the manifest
     with open(f"{basePath}/manifest.json", "r") as file:

--- a/buildtools/build.py
+++ b/buildtools/build.py
@@ -28,6 +28,14 @@ from time import time
 
 def parse_args():
     parser = ArgumentParser(prog="build", description=__doc__)
+    parser.add_argument("--name", "-N",
+                        type=str,
+                        default="Divine Journey 2",
+                        help="the name of the pack being released")
+    parser.add_argument("--version", "-V",
+                        type=str,
+                        required=False,
+                        help="the version of the pack being released")
     parser.add_argument("--prerelease", "-P",
                         action="store_true",
                         help="generates a name based on the manifest version, date of last commit, and sha of last commit")
@@ -100,6 +108,8 @@ symLinkDirs = [
 def print_argument_settings(args):
     """Prints what the build command will do"""
     print("starting the build process with the following settings")
+    print(f"name: {args.name}")
+    print(f"version: {args.version}")
     print(f"client: {args.client}")
     print(f"server: {args.server}")
     print(f"MultiMC-compatible Instance: {args.dev != None}")

--- a/buildtools/update_version.py
+++ b/buildtools/update_version.py
@@ -22,43 +22,10 @@ def parse_args():
                         type=str,
                         required=True,
                         help="the version being updated to")
-    parser.add_argument("--old", "-O",
-                        type=str,
-                        required=False,
-                        help="version being updated from, defaults to the latest git tag")
     return parser.parse_args()
 
 
 basePath = path.normpath(path.abspath(f"{__file__}/../../"))
-
-filesToUpdateVersion = [
-    "manifest.json",
-    "overrides/config/CustomMainMenu/mainmenu.json",
-    "overrides/config/mputils/addons/mpbasic/mpbasic.cfg"
-]
-
-
-def oldVersion() -> str:
-    """Get the current tag"""
-    try:
-        return run(["git", "describe", "--abbrev=0", "--tags"], capture_output=True, cwd=basePath).stdout.strip().decode("utf-8")
-    except:
-        print("could not determine git sha, skipping")
-    return ""
-
-
-def updateVersion(old: str, version: str):
-    """Replaces the old version number with the new version number in all targeted files"""
-    for file in filesToUpdateVersion:
-        f = open(file, "r")
-        filedata = f.read()
-        f.close()
-
-        newdata = filedata.replace(old, version)
-
-        with open(file, 'w') as new:
-            new.write(newdata)
-
 
 def convertChangelog(version: str):
     """Converts and filters the existing changelog in the LATEST.md file to a file named after the version"""
@@ -111,16 +78,6 @@ def convertChangelog(version: str):
 def process(args):
     """Converts the pack version in various files and converts the changelog file"""
 
-    old_version = args.old if args.old else oldVersion()
-
-    if old_version == "":
-        sys.exit("old version was not found, exiting")
-
-    if args.version == old_version:
-        print("old version was the same as new version, skipping")
-        return
-
-    updateVersion(old_version, args.version)
     convertChangelog(args.version)
     print("updated version-related files")
 

--- a/buildtools/update_version.py
+++ b/buildtools/update_version.py
@@ -88,7 +88,7 @@ def convertChangelog(version: str):
             file.write(f"\n{key}\n")
             for entry in value:
                 file.write(entry)
-        else:
+        if len(goal.items()) <= 0:
             file.write("\nCould not find a changelog")
 
     # Overwrite the in-game changelog file

--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -27,6 +27,9 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## GitHub Developments:
 
+- Improves the release generation scripts
+- Fixes a bug where "Could not find a changelog" was always printed
+- Fixes a bug where the server changelog was not written properly
 
 
 ## Miscellaneous Changes:

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "manifestType": "minecraftModpack",
   "manifestVersion": 1,
   "name": "Divine Journey 2",
-  "version": "2.21.0",
+  "version": "@PACK_VERSION@",
   "author": "AtricosHU",
   "files": [
     {

--- a/overrides/config/CustomMainMenu/mainmenu.json
+++ b/overrides/config/CustomMainMenu/mainmenu.json
@@ -182,7 +182,7 @@
             "alignment" : "bottom_left"
         },
         "modpack":{
-            "text" : "Divine Journey 2.21.0",
+            "text" : "Divine Journey @PACK_VERSION@",
             "posX" : 3,
             "posY" : -24,
             "fontSize" : 0.6,

--- a/overrides/config/mputils/addons/mpbasic/mpbasic.cfg
+++ b/overrides/config/mputils/addons/mpbasic/mpbasic.cfg
@@ -4,7 +4,7 @@
 
 changelog_settings {
     # Change button and Title of change log [default: What's New!]
-    S:"ChangeLog Title"=Update 2.21.0
+    S:"ChangeLog Title"=Update @PACK_VERSION@
 
     # Location of the file http or filename [default: changelog.txt]
     S:"File Address"=changelog.txt


### PR DESCRIPTION
changes in this PR:
- fixes server changelog not being added to CurseForge.
- replaces files with the specific pack version with `@PACK_VERSION@`.
- add `name` and `version` args to `build.py`.
- shorten `update-version.py`.
- updates some of the libraries used for building.
- fixes `Could not find a changelog` always being appending to the changelog.