### PR TITLE
Fix Laser Focus Names

### DIFF
--- a/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_diamatine.json
+++ b/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_diamatine.json
@@ -1,36 +1,36 @@
 {
     "machine": "laser_focus",
-    "registryName": "laser_focus_plustic_empowered_palis",
+    "registryName": "laser_focus_actuallyadditions_empowered_diamatine",
     "recipeTime": 20,
     "requirements": [
         {
             "type": "item",
             "io-type": "input",
-            "item": "thermalfoundation:material@259",
+            "item": "thermalfoundation:material@262",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "minecraft:prismarine_shard",
+            "item": "enderio:item_alloy_endergy_ingot@6",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "roots:moonglow_leaf",
+            "item": "roots:cloud_berry",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "enderio:item_material@39",
+            "item": "minecraft:clay",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "actuallyadditions:item_crystal@1",
+            "item": "actuallyadditions:item_crystal@2",
             "amount": 4
         },
         {
@@ -46,7 +46,7 @@
         {
             "type": "item",
             "io-type": "output",
-            "item": "actuallyadditions:item_crystal_empowered@1",
+            "item": "actuallyadditions:item_crystal_empowered@2",
             "amount": 4
         }
     ]

--- a/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_emeradic.json
+++ b/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_emeradic.json
@@ -1,36 +1,36 @@
 {
     "machine": "laser_focus",
-    "registryName": "laser_focus_plustic_empowered_diamatine",
+    "registryName": "laser_focus_actuallyadditions_empowered_emeradic",
     "recipeTime": 20,
     "requirements": [
         {
             "type": "item",
             "io-type": "input",
-            "item": "thermalfoundation:material@262",
+            "item": "enderio:item_material@13",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "enderio:item_alloy_endergy_ingot@6",
+            "item": "tconstruct:slime_congealed",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "roots:cloud_berry",
+            "item": "roots:spirit_herb",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "minecraft:clay",
+            "item": "minecraft:cactus",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "actuallyadditions:item_crystal@2",
+            "item": "actuallyadditions:item_crystal@4",
             "amount": 4
         },
         {
@@ -46,7 +46,7 @@
         {
             "type": "item",
             "io-type": "output",
-            "item": "actuallyadditions:item_crystal_empowered@2",
+            "item": "actuallyadditions:item_crystal_empowered@4",
             "amount": 4
         }
     ]

--- a/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_enori.json
+++ b/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_enori.json
@@ -1,36 +1,36 @@
 {
     "machine": "laser_focus",
-    "registryName": "laser_focus_plustic_empowered_glod",
+    "registryName": "laser_focus_actuallyadditions_empowered_enori",
     "recipeTime": 20,
     "requirements": [
         {
             "type": "item",
             "io-type": "input",
-            "item": "enderio:item_material@12",
+            "item": "thermalfoundation:material@288",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "thermalfoundation:material@294",
+            "item": "thermalfoundation:material@24",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "roots:wildewheet",
+            "item": "appliedenergistics2:material@5",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "minecraft:blaze_rod",
+            "item": "minecraft:snow",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "contenttweaker:glod_crystal",
+            "item": "actuallyadditions:item_crystal@5",
             "amount": 4
         },
         {
@@ -46,7 +46,7 @@
         {
             "type": "item",
             "io-type": "output",
-            "item": "contenttweaker:empowered_glod_crystal",
+            "item": "actuallyadditions:item_crystal_empowered@5",
             "amount": 4
         }
     ]

--- a/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_palis.json
+++ b/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_palis.json
@@ -1,36 +1,36 @@
 {
     "machine": "laser_focus",
-    "registryName": "laser_focus_plustic_empowered_emeradic",
+    "registryName": "laser_focus_actuallyadditions_empowered_palis",
     "recipeTime": 20,
     "requirements": [
         {
             "type": "item",
             "io-type": "input",
-            "item": "enderio:item_material@13",
+            "item": "thermalfoundation:material@259",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "tconstruct:slime_congealed",
+            "item": "minecraft:prismarine_shard",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "roots:spirit_herb",
+            "item": "roots:moonglow_leaf",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "minecraft:cactus",
+            "item": "enderio:item_material@39",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "actuallyadditions:item_crystal@4",
+            "item": "actuallyadditions:item_crystal@1",
             "amount": 4
         },
         {
@@ -46,7 +46,7 @@
         {
             "type": "item",
             "io-type": "output",
-            "item": "actuallyadditions:item_crystal_empowered@4",
+            "item": "actuallyadditions:item_crystal_empowered@1",
             "amount": 4
         }
     ]

--- a/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_restonia.json
+++ b/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_restonia.json
@@ -1,36 +1,36 @@
 {
     "machine": "laser_focus",
-    "registryName": "laser_focus_plustic_empowered_enori",
+    "registryName": "laser_focus_actuallyadditions_empowered_restonia",
     "recipeTime": 20,
     "requirements": [
         {
             "type": "item",
             "io-type": "input",
-            "item": "thermalfoundation:material@288",
+            "item": "thermalfoundation:material@293",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "thermalfoundation:material@24",
+            "item": "enderio:item_alloy_ingot@3",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "appliedenergistics2:material@5",
+            "item": "minecraft:brick_block",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "minecraft:snow",
+            "item": "roots:infernal_bulb",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "actuallyadditions:item_crystal@5",
+            "item": "actuallyadditions:item_crystal@0",
             "amount": 4
         },
         {
@@ -46,7 +46,7 @@
         {
             "type": "item",
             "io-type": "output",
-            "item": "actuallyadditions:item_crystal_empowered@5",
+            "item": "actuallyadditions:item_crystal_empowered@0",
             "amount": 4
         }
     ]

--- a/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_void.json
+++ b/overrides/config/modularmachinery/recipes/laser_focus_actuallyadditions_empowered_void.json
@@ -1,36 +1,36 @@
 {
     "machine": "laser_focus",
-    "registryName": "laser_focus_plustic_empowered_restonia",
+    "registryName": "laser_focus_actuallyadditions_empowered_void",
     "recipeTime": 20,
     "requirements": [
         {
             "type": "item",
             "io-type": "input",
-            "item": "thermalfoundation:material@293",
+            "item": "thermalfoundation:material@290",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "enderio:item_alloy_ingot@3",
+            "item": "enderio:item_material@73",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "minecraft:brick_block",
+            "item": "minecraft:coal@1",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "roots:infernal_bulb",
+            "item": "minecraft:flint",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "actuallyadditions:item_crystal@0",
+            "item": "actuallyadditions:item_crystal@3",
             "amount": 4
         },
         {
@@ -46,7 +46,7 @@
         {
             "type": "item",
             "io-type": "output",
-            "item": "actuallyadditions:item_crystal_empowered@0",
+            "item": "actuallyadditions:item_crystal_empowered@3",
             "amount": 4
         }
     ]

--- a/overrides/config/modularmachinery/recipes/laser_focus_contenttweaker_empowered_crystal_bundle.json
+++ b/overrides/config/modularmachinery/recipes/laser_focus_contenttweaker_empowered_crystal_bundle.json
@@ -1,6 +1,6 @@
 {
     "machine": "laser_focus",
-    "registryName": "laser_focus_plustic_empowered_crystal_bundle",
+    "registryName": "laser_focus_contenttweaker_empowered_crystal_bundle",
     "recipeTime": 20,
     "requirements": [
         {

--- a/overrides/config/modularmachinery/recipes/laser_focus_contenttweaker_empowered_glod.json
+++ b/overrides/config/modularmachinery/recipes/laser_focus_contenttweaker_empowered_glod.json
@@ -1,36 +1,36 @@
 {
     "machine": "laser_focus",
-    "registryName": "laser_focus_plustic_empowered_void",
+    "registryName": "laser_focus_contenttweaker_empowered_glod",
     "recipeTime": 20,
     "requirements": [
         {
             "type": "item",
             "io-type": "input",
-            "item": "thermalfoundation:material@290",
+            "item": "enderio:item_material@12",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "enderio:item_material@73",
+            "item": "thermalfoundation:material@294",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "minecraft:coal@1",
+            "item": "roots:wildewheet",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "minecraft:flint",
+            "item": "minecraft:blaze_rod",
             "amount": 4
         },
         {
             "type": "item",
             "io-type": "input",
-            "item": "actuallyadditions:item_crystal@3",
+            "item": "contenttweaker:glod_crystal",
             "amount": 4
         },
         {
@@ -46,7 +46,7 @@
         {
             "type": "item",
             "io-type": "output",
-            "item": "actuallyadditions:item_crystal_empowered@3",
+            "item": "contenttweaker:empowered_glod_crystal",
             "amount": 4
         }
     ]


### PR DESCRIPTION
changes in this PR:
- fixes an issue from #1172 where the laser focus recipes had the incorrect names - this has no impact in-game, its just for consistency.