### PR TITLE
Python update/build script fixes

### DIFF
--- a/buildtools/build.py
+++ b/buildtools/build.py
@@ -481,6 +481,25 @@ def updateMMCInstance(instancePath: str):
     print("your instance is now linked to the git repo")
 
 
+def zipPack(version: str, args: dict):
+    """Create a zip for the pack for the client and server, if requested"""
+    # Get the standard name of the pack
+    standardName = getStandardName(args.name, version)
+
+    # Get the date and sha of the most recent git commit
+    preReleaseName = getPreReleaseName() if args.prerelease else ""
+
+    archive_name = f"{standardName}_{preReleaseName}" if preReleaseName else standardName
+
+    # Zip the client
+    if (args.client):
+        buildClient(archive_name)
+
+    # Zip the server
+    if (args.server):
+        buildServer(f"{archive_name}_Server_Pack")
+
+
 def printTime(start: int, description: str):
     """Print the time since the start for the given task to be accomplished"""
     print(f"{description} {str(round(time() - start, 2))} seconds")
@@ -552,21 +571,7 @@ def build(args: dict):
         convertPackVersion(server, version, filesToUpdateVersionServer)
 
     if (args.zip):
-        # Get the standard name of the pack
-        standardName = getStandardName(args.name, version)
-
-        # Get the date and sha of the most recent git commit
-        preReleaseName = getPreReleaseName() if args.prerelease else ""
-
-        archive_name = f"{standardName}_{preReleaseName}" if preReleaseName else standardName
-
-        # Zip the client
-        if (args.client):
-            buildClient(archive_name)
-
-        # Zip the server
-        if (args.server):
-            buildServer(f"{archive_name}_Server_Pack")
+        zipPack(version, args)
 
     if (args.dev):
         updateMMCInstance(args.dev)

--- a/buildtools/build.py
+++ b/buildtools/build.py
@@ -477,6 +477,11 @@ def updateMMCInstance(instancePath: str):
     print("your instance is now linked to the git repo")
 
 
+def printTime(start: int, description: str):
+    """Print the time since the start for the given task to be accomplished"""
+    print(f"{description} {str(round(time() - start, 2))} seconds")
+
+
 def build(args):
     """Build client, server, and with options for more"""
 
@@ -507,24 +512,24 @@ def build(args):
     createBaseDir()
 
     if (args.download):
-        print(f"starting download process at {str(round(time() - start, 2))} seconds")
+        printTime(start, "starting download process at")
 
         # Download any external dependencies defined in the manifest, and add successful downloads to the modlist
         externalDeps(manifest, args.retries)
-        print(f"downloaded external dependencies in {str(round(time() - start, 2))} seconds")
+        printTime(start, "downloaded external dependencies in")
 
         # Create modlist
         generateModlist(manifest, args.key, modlistServer, modlistClient, args.retries)
-        print(f"generated a modlist to download in {str(round(time() - start, 2))} seconds")
+        printTime(start, "generated a modlist to download in")
 
         # Download mods
         downloadModList(modlistServer, modlistClient, args.retries)
-        print(f"downloaded the modlist in {str(round(time() - start, 2))} seconds")
+        printTime(start, "downloaded the modlist in")
 
     # Download and install Forge and its libraries
     if (args.server):
         forgeInstaller(manifest)
-        print(f"installed the forge installer in {str(round(time() - start, 2))} seconds")
+        printTime(start, "installed the forge installer in")
 
     # Get the modpack version from git tags if not an argument
     version = getGitTagVersion() if args.version == None else args.version
@@ -559,7 +564,7 @@ def build(args):
     if (args.dev):
         updateMMCInstance(args.dev)
 
-    print(f"done in {str(round(time() - start, 2))} seconds")
+    printTime(start, "done in")
 
 
 if (__name__ == "__main__"):

--- a/buildtools/build.py
+++ b/buildtools/build.py
@@ -116,7 +116,7 @@ filesToUpdateVersionServer = [
     "config/mputils/addons/mpbasic/mpbasic.cfg"
 ]
 
-def print_argument_settings(args):
+def print_argument_settings(args: dict):
     """Prints what the build command will do"""
     print("starting the build process with the following settings")
     print(f"name: {args.name}")
@@ -223,7 +223,7 @@ def generateModlist(manifest: dict, key: str, modlistServer: list, modlistClient
     print("modlist compiled")
 
 
-def externalDeps(manifest, retries: int):
+def externalDeps(manifest: dict, retries: int):
     """If we have external dependencies, try to download them"""
     counter = 0
 
@@ -343,21 +343,21 @@ def convertPackVersion(root: str, version: str, locations: list):
                 new.write(newdata)
 
 
-def getForgeVersion(manifest):
+def getForgeVersion(manifest: dict):
     """Get the Forge version"""
     forgeVer = manifest["minecraft"]["modLoaders"][0]["id"].split("-")[-1]
     mcVer = manifest["minecraft"]["version"]
     return f"forge-{mcVer}-{forgeVer}.jar"
 
 
-def getForgeInstaller(manifest):
+def getForgeInstaller(manifest: dict):
     """Get the URL to the Forge installer"""
     forgeVer = manifest["minecraft"]["modLoaders"][0]["id"].split("-")[-1]
     mcVer = manifest["minecraft"]["version"]
     return f"https://maven.minecraftforge.net/net/minecraftforge/forge/{mcVer}-{forgeVer}/forge-{mcVer}-{forgeVer}-installer.jar"
 
 
-def forgeInstaller(manifest):
+def forgeInstaller(manifest: dict):
     """Download the Forge Installer and install it"""
     with open(f"{cache}/forge-installer.jar", "w+b") as jar:
         url = getForgeInstaller(manifest)
@@ -412,7 +412,7 @@ def copyClient():
             shutil.rmtree(location, ignore_errors=True)
 
 
-def copyServer(manifest):
+def copyServer(manifest: dict):
     """Copy required contents to server instance, and then delete designated files"""
     shutil.copy(f"{basePath}/manifest.json", f"{server}/manifest.json")
     shutil.copy(f"{basePath}/LICENSE", f"{server}/LICENSE")
@@ -486,7 +486,7 @@ def printTime(start: int, description: str):
     print(f"{description} {str(round(time() - start, 2))} seconds")
 
 
-def build(args):
+def build(args: dict):
     """Build client, server, and with options for more"""
 
     print_argument_settings(args)

--- a/buildtools/build.py
+++ b/buildtools/build.py
@@ -130,6 +130,18 @@ def print_argument_settings(args):
     print(f"deleting prior files: {args.wipe}")
 
 
+def getApiKey(key: str) -> str:
+    """Return the CurseForge API key"""
+    if (key == None):
+        key = os.getenv("CFAPIKEY")
+
+    if (key == None):
+        with open(f"{basePath}/buildtools/API-KEY", "r") as file:
+            key = file.readline().replace("\n", "")
+
+    return key
+
+
 def createBaseDir():
     """Create the client, server, cache, and mods directory"""
     os.makedirs(client, exist_ok=True)
@@ -188,14 +200,6 @@ def generateModlist(manifest: dict, key: str, modlistServer: list, modlistClient
     print("getting the download url of all mods")
 
     failedModDownload = []
-
-    # Curseforge api key
-    if (key == None):
-        os.getenv("CFAPIKEY")
-
-    if (key == None):
-        with open(f"{basePath}/buildtools/API-KEY", "r") as file:
-            key = file.readline().replace("\n", "")
 
     access = requests.Session()
     access.mount("https://", HTTPAdapter(max_retries=Retry(total=retries, backoff_factor=1)))
@@ -496,6 +500,9 @@ def build(args):
         print("you must specify either client, server, or dev")
         return
 
+    # Curseforge api key
+    apiKey = getApiKey(args.key)
+
     # Read the manifest
     with open(f"{basePath}/manifest.json", "r") as file:
         manifest = json.load(file)
@@ -519,7 +526,7 @@ def build(args):
         printTime(start, "downloaded external dependencies in")
 
         # Create modlist
-        generateModlist(manifest, args.key, modlistServer, modlistClient, args.retries)
+        generateModlist(manifest, apiKey, modlistServer, modlistClient, args.retries)
         printTime(start, "generated a modlist to download in")
 
         # Download mods

--- a/buildtools/build.py
+++ b/buildtools/build.py
@@ -105,12 +105,15 @@ symLinkDirs = [
     "structures"
 ]
 # Files which contain a "@PACK_VERSION@" which must be replaced with the pack variable number
-filesToUpdateVersion = [
+filesToUpdateVersionClient = [
+    "manifest.json",
+    "overrides/config/CustomMainMenu/mainmenu.json",
+    "overrides/config/mputils/addons/mpbasic/mpbasic.cfg"
+]
+filesToUpdateVersionServer = [
     "manifest.json",
     "config/CustomMainMenu/mainmenu.json",
     "config/mputils/addons/mpbasic/mpbasic.cfg"
-    "overrides/config/CustomMainMenu/mainmenu.json",
-    "overrides/config/mputils/addons/mpbasic/mpbasic.cfg"
 ]
 
 def print_argument_settings(args):
@@ -321,10 +324,10 @@ def getPreReleaseName() -> str:
     return ""
 
 
-def convertPackVersion(location: str, version: str):
+def convertPackVersion(root: str, version: str, locations: list):
     """Convert the @PACK_VERSION@ placeholders into the actual pack version being used"""
-    for target in filesToUpdateVersion:
-        file = f"{location}/{target}"
+    for target in locations:
+        file = f"{root}/{target}"
         if os.path.isfile(file) and os.path.exists(file):
             f = open(file, "r")
             filedata = f.read()
@@ -529,12 +532,12 @@ def build(args):
     # Copy required files to the client instance
     if (args.client):
         copyClient()
-        convertPackVersion(client, version)
+        convertPackVersion(client, version, filesToUpdateVersionClient)
 
     # Copy required files to the server instance
     if (args.server):
         copyServer(manifest)
-        convertPackVersion(server, version)
+        convertPackVersion(server, version, filesToUpdateVersionServer)
 
     if (args.zip):
         # Get the standard name of the pack

--- a/buildtools/update_version.py
+++ b/buildtools/update_version.py
@@ -26,6 +26,9 @@ def parse_args():
 
 
 basePath = path.normpath(path.abspath(f"{__file__}/../../"))
+UPDATE_QUESTBOOK = f"""YOU'LL NEED TO UPDATE YOUR QUEST BOOK BY TYPING:
+/bq_admin default load
+(This has to only be done once in multiplayer, by an admin.)\n"""
 
 def convertChangelog(version: str):
     """Converts and filters the existing changelog in the LATEST.md file to a file named after the version"""
@@ -60,13 +63,11 @@ def convertChangelog(version: str):
 
     # Overwrite the in-game changelog file
     with open("overrides/config/mputils/changelog.txt", "w") as file:
-        file.write(f"""YOU'LL NEED TO UPDATE YOUR QUEST BOOK BY TYPING:
-/bq_admin default load
-(This has to only be done once in multiplayer, by an admin.)
-""")
+        file.write(UPDATE_QUESTBOOK)
         file.write(f"\nUpdate {version}:\n")
         with open(changelogFile) as changelog:
-            file.write(changelog.read())
+            with open(changelogFile) as changelog:
+                print(f"changelog={UPDATE_QUESTBOOK}{changelog.read()}", file=fh)
 
     if getenv("GITHUB_OUTPUT") != None:
         with open(getenv("GITHUB_OUTPUT"), "a") as fh:

--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -29,5 +29,6 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 - Fix the main menu containing `@PACK_VERSION@` instead of the actual version.
 - Improve the usability of the `build.py` build tool.
+- Fix `update_version.py` not loading the changelog text onto CurseForge and requiring manual intervention.
 
 ## Miscellaneous Changes:

--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -7,7 +7,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## Bugfixes:
 
-
+- Fix the main menu containing `@PACK_VERSION@` instead of the actual version.
 
 ## Balance Adjustments:
 
@@ -27,6 +27,6 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## GitHub Developments:
 
-
+- Fix the main menu containing `@PACK_VERSION@` instead of the actual version.
 
 ## Miscellaneous Changes:

--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -28,5 +28,6 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 ## GitHub Developments:
 
 - Fix the main menu containing `@PACK_VERSION@` instead of the actual version.
+- Improve the usability of the `build.py` build tool.
 
 ## Miscellaneous Changes:


### PR DESCRIPTION
changes in this PR:
- fix the issue where `@PACK_VERSION@` appears on the title screen due to not being replaced when the pack is getting released.
- fix the issue where updating would not upload the changelog to curseforge, but instead just the file name.
- clean some methods up in the buildscript.