### PR TITLE
Changed the Toe of Frog output in the Mob Loot Fabricator from 0.001% to 100%.

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -11,7 +11,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## Balance Adjustments:
 
-
+Changed the Toe of Frog output in the Mob Loot Fabricator from 0.001% to 100%.
 
 ## QoL Improvements:
 

--- a/overrides/config/modularmachinery/recipes/mob_loot_fabricator_bewitchment.json
+++ b/overrides/config/modularmachinery/recipes/mob_loot_fabricator_bewitchment.json
@@ -85,7 +85,7 @@
             "type": "item",
             "io-type": "output",
             "item": "bewitchment:toe_of_frog",
-            "chance": 0.00001
+            "amount": 1
         }
     ]
 }


### PR DESCRIPTION
Rn the Toe of Frog in the MLF is just a joke, make it 100% or maybe down to 1%, else remove it completely.

Renaming a branch closes the PR so I'm opening it again, whoops.