### PR TITLE
Changed the Water Mill nerf from 25% to 50% to make them at all viable.

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -11,7 +11,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## Balance Adjustments:
 
-
+Changed the Water Mill nerf from 25% to 50% to make them at all viable.
 
 ## QoL Improvements:
 

--- a/overrides/config/tmel.cfg
+++ b/overrides/config/tmel.cfg
@@ -226,14 +226,14 @@ general {
         D:"Lunar Panel"=1.0
         D:"Manual Mill"=1.0
         D:"Solar Panel"=1.0
-        D:"Water Mill"=0.25
+        D:"Water Mill"=0.5
         D:"Wind Mill"=2.0
         D:创造模式发电机=10000.0
         D:太阳能面板=1.0
         D:岩浆发电机=1.0
         D:手动发电机=1.0
         D:月光面板=1.0
-        D:水力发电机=0.25
+        D:水力发电机=0.5
         D:火力发电机=2.0
         D:熔岩发电机=2.0
         D:风力发电机=2.0


### PR DESCRIPTION
The Water Mill nerf rn is so severe that it's basically unusable because the Fire Mill with 8GP and Lava Mill with 7GP in the Nether are just way better in terms of space and resource efficiency.
If you want to make people not use the Water Mill at all because you find it to too easy then I recommend just removing it entirely, else I'd try to integrate it correctly by not nerfing it to the ground but rather nerf it enough to make it as viable as all the others.