### PR TITLE
Increased the LE output of the MLF BM recipe from 8B to 16B which is the cap of the minimum usable Fluid Output Hatch to reduce lag.

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -15,7 +15,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## QoL Improvements:
 
-
+Increased the LE output of the Mob Loot Fabricator Blood Magic recipe from 8B to 16B which is the cap of the minimum usable Fluid Output Hatch to reduce lag.
 
 ## Text and Quest Updates:
 

--- a/overrides/config/modularmachinery/recipes/mob_loot_fabricator_blood_magic.json
+++ b/overrides/config/modularmachinery/recipes/mob_loot_fabricator_blood_magic.json
@@ -59,7 +59,7 @@
             "type": "fluid",
             "io-type": "output",
             "fluid": "lifeessence",
-            "amount": 8000
+            "amount": 16000
         },
         {
             "type": "item",


### PR DESCRIPTION
MLFs replace mob farms but are still quite laggy compared to other machines so setting their outputs to a high batch decreases the need for multiple which decreases lag.