### PR TITLE
Added the missing block in the Laser Focus multiblock.

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -15,7 +15,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## QoL Improvements:
 
-
+Added the missing block in the Laser Focus multiblock.
 
 ## Text and Quest Updates:
 

--- a/overrides/config/betterquesting/DefaultQuests.json
+++ b/overrides/config/betterquesting/DefaultQuests.json
@@ -18696,7 +18696,7 @@
             },
             "4:10": {
               "id:8": "contenttweaker:portion_of_the_sun",
-              "Count:3": 7
+              "Count:3": 8
             },
             "5:10": {
               "id:8": "contenttweaker:reinforced_glass_casing",

--- a/overrides/config/modularmachinery/machinery/laser_focus.json
+++ b/overrides/config/modularmachinery/machinery/laser_focus.json
@@ -803,6 +803,14 @@
             ]
         },
         {
+            "x": 0,
+            "y": 3,
+            "z": 7,
+            "elements": [
+                "contenttweaker:portion_of_the_sun@0"
+            ]
+        },
+        {
             "x": -1,
             "y": 3,
             "z": 7,


### PR DESCRIPTION
Has been missing since forever and when looking at the back/arm from the side without the Reinforced Machine Casings it's clear that the whole inside should be the Portion of the Sun blocks.
Also since you get 5 Portions per batch it didn't change anything crafting wise since now you need 8 isntead of 7 so you trash 2 instead of 3.