### PR TITLE
Fixed the Filter Module saying the same whitelist mode in it's UI and tooltip when crafted.

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -15,7 +15,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## QoL Improvements:
 
-
+Fixed the Filter Module saying the same whitelist mode in it's UI and tooltip when crafted.
 
 ## Text and Quest Updates:
 

--- a/overrides/scripts/ModSpecific/RFTools.zs
+++ b/overrides/scripts/ModSpecific/RFTools.zs
@@ -217,6 +217,10 @@ recipes.addShaped(<rftools:matter_beamer>, [[<enderio:item_material:73>,<ore:glo
 recipes.remove(<rftools:syringe>);
 recipes.addShapedMirrored(<rftools:syringe>, [[<enderio:item_alloy_ingot:6>,<enderio:item_alloy_ingot:6>,null],[<enderio:item_alloy_ingot:6>,<enderio:item_soul_vial>,<contenttweaker:crystalline_brown_slime_ingot>],[null,<contenttweaker:crystalline_brown_slime_ingot>,<enderio:item_alloy_ingot:6>]]);
 
+// Filter Module
+recipes.remove(<rftools:filter_module>);
+recipes.addShaped(<rftools:filter_module>.withTag({blacklistMode:"White"}), [[null,<minecraft:hopper>,null],[<minecraft:redstone>,<minecraft:iron_ingot>,<minecraft:redstone>],[null,<minecraft:paper>,null]]);
+
 // Item Filter
 recipes.remove(<rftools:item_filter>);
 recipes.addShaped(<rftools:item_filter>, [[<enderio:item_alloy_ingot:6>,<enderio:item_alloy_ingot:3>,<enderio:item_alloy_ingot:6>],[<ironchest:iron_chest>,<rftools:machine_frame>,<ironchest:iron_chest>],[<enderio:item_alloy_ingot:6>,<enderio:item_alloy_ingot:3>,<enderio:item_alloy_ingot:6>]]);


### PR DESCRIPTION
By default the crafted Filter Module is in whitelist which the tooltip says correctly, but the UI shows that it's in blacklist. This is very confusing since you have to toggle it once to "sync" both infos. Giving the Filter the NBT for being whitelist makes both show the same correct info.