### PR TITLE
Crafted Impulse Hopper is locked by default.

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -15,7 +15,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## QoL Improvements:
 
-
+Crafted Impulse Hopper is locked by default.
 
 ## Text and Quest Updates:
 

--- a/overrides/scripts/ModSpecific/EnderIO.zs
+++ b/overrides/scripts/ModSpecific/EnderIO.zs
@@ -386,8 +386,8 @@ enderIOCapBankUpgrade, null);
 
 // Impulse Hopper
 recipes.remove(<enderio:block_impulse_hopper>);
-recipes.addShaped(<enderio:block_impulse_hopper>, [[<enderio:item_alloy_ingot:6>,<enderio:item_material:13>,<enderio:item_alloy_ingot:6>],[<mob_grinding_utils:absorption_hopper>,<enderio:item_material:1>,<mob_grinding_utils:absorption_hopper>],[<enderio:item_alloy_ingot:6>,<enderio:item_material:13>,<enderio:item_alloy_ingot:6>]]);
-recipes.addShaped(<enderio:block_impulse_hopper>, [[<enderio:item_alloy_ingot:6>,<mob_grinding_utils:absorption_hopper>,<enderio:item_alloy_ingot:6>],[<enderio:item_material:13>,<enderio:item_material:1>,<enderio:item_material:13>],[<enderio:item_alloy_ingot:6>,<mob_grinding_utils:absorption_hopper>,<enderio:item_alloy_ingot:6>]]);
+recipes.addShaped(<enderio:block_impulse_hopper>.withTag({"enderio:data":{isOutputLocked:1}}), [[<enderio:item_alloy_ingot:6>,<enderio:item_material:13>,<enderio:item_alloy_ingot:6>],[<mob_grinding_utils:absorption_hopper>,<enderio:item_material:1>,<mob_grinding_utils:absorption_hopper>],[<enderio:item_alloy_ingot:6>,<enderio:item_material:13>,<enderio:item_alloy_ingot:6>]]);
+recipes.addShaped(<enderio:block_impulse_hopper>.withTag({"enderio:data":{isOutputLocked:1}}), [[<enderio:item_alloy_ingot:6>,<mob_grinding_utils:absorption_hopper>,<enderio:item_alloy_ingot:6>],[<enderio:item_material:13>,<enderio:item_material:1>,<enderio:item_material:13>],[<enderio:item_alloy_ingot:6>,<mob_grinding_utils:absorption_hopper>,<enderio:item_alloy_ingot:6>]]);
 
 // Energy Gauge
 recipes.remove(<enderio:block_gauge>);


### PR DESCRIPTION
Haven't seen a single setup where an Impulse Hopper isn't locked and logically you always wanna lock it since else setups will just break because batches will get mixed up.