### PR TITLE
Correct order of gating for Signalum and Resonant Upgrade Kits.

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -11,7 +11,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## Balance Adjustments:
 
-
+Correct order of gating for Signalum and Resonant Upgrade Kits.
 
 ## QoL Improvements:
 

--- a/overrides/scripts/ModSpecific/ThermalFoundation.zs
+++ b/overrides/scripts/ModSpecific/ThermalFoundation.zs
@@ -72,12 +72,12 @@ recipes.addShaped(<thermalfoundation:upgrade:1>, [[<contenttweaker:fluxed_electr
 // Signalum Upgrade Kit
 thermalKitTooltip(<thermalfoundation:upgrade:2>, 150, 16, 54);
 recipes.remove(<thermalfoundation:upgrade:2>);
-recipes.addShaped(<thermalfoundation:upgrade:2>, [[<thermalfoundation:material:327>,<thermalfoundation:material:327>,<thermalfoundation:material:327>],[<thermalfoundation:material:327>,<thermalfoundation:storage_alloy:5>,<thermalfoundation:material:327>],[<thermalfoundation:material:514>,<thermalfoundation:material:514>,<thermalfoundation:material:514>]]);
+recipes.addShaped(<thermalfoundation:upgrade:2>, [[<extendedcrafting:material:2>,<extendedcrafting:material:2>,<extendedcrafting:material:2>],[<extendedcrafting:material:2>,<thermalfoundation:storage_alloy:5>,<extendedcrafting:material:2>],[<thermalfoundation:material:514>,<thermalfoundation:material:514>,<thermalfoundation:material:514>]]);
 
 // Resonant Upgrade Kit
 thermalKitTooltip(<thermalfoundation:upgrade:3>, 200, 25, 82);
 recipes.remove(<thermalfoundation:upgrade:3>);
-recipes.addShaped(<thermalfoundation:upgrade:3>, [[<extendedcrafting:material:2>,<extendedcrafting:material:2>,<extendedcrafting:material:2>],[<extendedcrafting:material:2>,<thermalfoundation:storage_alloy:7>,<extendedcrafting:material:2>],[<thermalfoundation:material:515>,<thermalfoundation:material:515>,<thermalfoundation:material:515>]]);
+recipes.addShaped(<thermalfoundation:upgrade:3>, [[<thermalfoundation:material:327>,<thermalfoundation:material:327>,<thermalfoundation:material:327>],[<thermalfoundation:material:327>,<thermalfoundation:storage_alloy:7>,<thermalfoundation:material:327>],[<thermalfoundation:material:515>,<thermalfoundation:material:515>,<thermalfoundation:material:515>]]);
 
 // Signalum Security Lock
 recipes.remove(<thermalfoundation:security>);


### PR DESCRIPTION
Signalum Kit is gated By Iridium which is ch13, Resonant Kit is gated by Black Iron which is ch12, swapped those 2 in their recipes.