### PR TITLE
serverfiles/launch.sh: use `/bin/bash` instead of `/bin/sh`

### DIFF
--- a/serverfiles/launch.sh
+++ b/serverfiles/launch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Server Launch Script
 #
 # Thrown together by Neeve in under five minutes, Public Domain


### PR DESCRIPTION
I am working on a [Pelican egg](https://github.com/pelican-eggs) for Divine Journey (which I will share once working), and I realized that the shebang on the `launch.sh` script was wrong, because it uses bash features.
However, it's right in the `autolaunch.sh` script