### PR TITLE
Fix UT causing a server crash

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -6,6 +6,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## Bugfixes:
 
+- Fix a bug wherein Universal Tweaks tried to load a client-only class, crashing servers.
 
 ## Balance Adjustments:
 

--- a/overrides/config/Universal Tweaks - Mod Integration.cfg
+++ b/overrides/config/Universal Tweaks - Mod Integration.cfg
@@ -21,7 +21,7 @@ general {
         # 1 disables the creation of these particles when the Particle setting is on Minimal only
         # 2 disables the creation of these particles when the Particle setting is on Decreased or Minimal
         # 3 or higher will never disable these particles
-        I:"Item Laser Particles Graphics"=2
+        I:"Item Laser Particles Graphics"=-1
 
         # Fixes Laser Upgrades voiding instead of applying if there is only one item in the stack
         B:"Laser Upgrade Voiding"=true


### PR DESCRIPTION
changes in this PR:
- disable the UT config for AA item laser particles, as it tries to load a client-only class on the server

resolve #1239