### PR TITLE
Update Featured Server

### DIFF
--- a/overrides/config/FeaturedServers/featuredservers.json
+++ b/overrides/config/FeaturedServers/featuredservers.json
@@ -1,6 +1,6 @@
 [
   {
-    "serverName": "[Featured] Pixel Gaming (PvE/EU)",
-    "serverIP": "dj2.pixelgaming.co"
+    "serverName": "[Featured] Apollo Network (PvE/EU)",
+    "serverIP": "dj2.apollonetwork.org"
   }
 ]


### PR DESCRIPTION
The Pixel Gaming Network will shut-down end of June.

Pixel Gaming has decided to allow players to transfer their items and bases over to the new featured server.
A world download will also be made available, when the servers shut down, to allow people to continue playing.