### PR TITLE
Update Github Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/000-crash-report.yml
+++ b/.github/ISSUE_TEMPLATE/000-crash-report.yml
@@ -1,12 +1,15 @@
-name: Crash report
-description: The game crashed on a certain action
+name: Crash Report
+description: The game crashed on a certain action.
 labels: ["Crash"]
+type: Bug
 body:
   - type: markdown
     attributes:
       value: |
-        First, check if your request has been submitted before or is a [Known Issue](https://github.com/Divine-Journey-2/main/issues?q=label%253A%22Known+Issue%22). If it is, please don't submit a duplicate.
-        Then, if you have Optifine installed and the crash is related to a visual issue, remove Optifine and confirm that it happens without Optifine.
+        Before submitting an issue, check if your request has been submitted before. If it has, please don't submit a duplicate.
+        In particular, check if it is a [Known Issue](https://github.com/Divine-Journey-2/Divine-Journey-2/issues?q=state%3Aopen%20label%3A"Known Issue").
+        Then, if you have OptiFine installed and the crash is related to a visual issue, remove OptiFine and confirm that it happens without OptiFine.
+        If you are not using the latest version, make sure that the report has not already been [resolved](https://github.com/Divine-Journey-2/Divine-Journey-2/commits/main/).
   - type: input
     id: modpack-version
     attributes:
@@ -19,7 +22,7 @@ body:
     id: java-version
     attributes:
       label: Java version
-      description: "Note: if you are using Curseforge as the launcher, due to a bug with Curseforge, you are using Java 1.8.0_51 (check your crash log). As you are using a Java version that dates to late 2015, you will run into a number of issues you wouldn't otherwise."
+      description: "Note: if you are using CurseForge as the launcher, due to a bug with CurseForge, you are using Java 1.8.0_51 (check your crash log). As you are using a Java version that dates to late 2015, you will run into a number of issues you wouldn't otherwise."
       placeholder: "Example: 1.8.0_311"
     validations:
       required: true
@@ -64,7 +67,8 @@ body:
         Crash reports are found in the `your_minecraft_instance/crash-reports` folder.
         If no crash report generated, please include the `your_mincraft_instance/logs/latest.log` file. Note that the latest.log is overwritten every time you launch the game, and so this must happen as soon as you crash.
         You can attach any number of crash reports, but please describe when each of them occurred.
-        You can either upload the file directly to github, or use [pastebin](https://pastebin.com/), [paste.ee](https://paste.ee/), or any other paste site.
+        You can either upload the file directly to github, or use [pastebin](https://pastebin.com/), [paste.ee](https://paste.ee/), [mclogs](https://mclo.gs), or any other paste site.
+        **Do not paste the contents of either these files directly into the text box.**
     validations:
       required: true
   - type: textarea
@@ -79,4 +83,8 @@ body:
     attributes:
       label: Your Divine Journey 2 Discord Username
       description: If you haven't joined the Discord, this will make it harder to contact you if we need additional info.
-      placeholder: "Example: Dyno#3861"
+      placeholder: "Example: atricos, waitingidly"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make this crash report!

--- a/.github/ISSUE_TEMPLATE/001-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/001-bug-report.yml
@@ -1,12 +1,15 @@
-name: Bug report
+name: Bug Report
 description: There is a bug that needs to be fixed.
 labels: ["Bug"]
+type: Bug
 body:
   - type: markdown
     attributes:
       value: |
-        First, check if your request has been submitted before or is a [Known Issue](https://github.com/Divine-Journey-2/main/issues?q=label%253A%22Known+Issue%22). If it is, please don't submit a duplicate.
-        Then, if you have Optifine installed and it is a visual bug, remove Optifine and confirm that it happens without Optifine.
+        Before submitting an issue, check if your request has been submitted before. If it has, please don't submit a duplicate.
+        In particular, check if it is a [Known Issue](https://github.com/Divine-Journey-2/Divine-Journey-2/issues?q=state%3Aopen%20label%3A"Known Issue").
+        Then, if you have OptiFine installed and it is a visual bug, remove OptiFine and confirm that it happens without OptiFine.
+        If you are not using the latest version, make sure that the report has not already been [resolved](https://github.com/Divine-Journey-2/Divine-Journey-2/commits/main/).
   - type: input
     id: modpack-version
     attributes:
@@ -52,4 +55,8 @@ body:
     attributes:
       label: Your Divine Journey 2 Discord Username
       description: If you haven't joined the Discord, this will make it harder to contact you if we need additional info.
-      placeholder: "Example: Dyno#3861"
+      placeholder: "Example: atricos, waitingidly"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make this bug report!

--- a/.github/ISSUE_TEMPLATE/002-typo-report.yml
+++ b/.github/ISSUE_TEMPLATE/002-typo-report.yml
@@ -32,8 +32,10 @@ body:
     id: typo-location
     attributes:
       label: Where is the typo located?
-      description: eg Quests / Title Screen / Tooltips / Advancements. If possible, link the location in the DJ2 code it occurs.
-      placeholder: "Example: In the 19th Chapter in the description of the Quest called ... "
+      description: |
+        eg Quests / Title Screen / Tooltips / Advancements. If possible, link the location in the DJ2 code it occurs.
+        Note: *please* do not use the pound symbol (`#`) before the quest id unless it is formatted in code. Doing this will cause it to link to a GitHub issue, causing noise and clutter.
+      placeholder: "Example: quest \\``#57`\\` had ... / quest id 57 had ... / In the 19th Chapter in the description of the Quest called ... "
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/002-typo-report.yml
+++ b/.github/ISSUE_TEMPLATE/002-typo-report.yml
@@ -1,16 +1,31 @@
-name: Typo
-description: There is a typo / misspelling / grammatical error somewhere.
+name: Typo Report
+description: There is a typo / misspelling / untranslated text / grammatical error somewhere.
 labels: ["Typo"]
+type: Bug
 body:
   - type: markdown
     attributes:
-      value: Before submitting an issue, check if your request has been submitted before. If it has, please don't submit a duplicate.
+      value: |
+        Before submitting an issue, check if your request has been submitted before. If it has, please don't submit a duplicate.
+        If the typo occurs in the questbook, please add the Questbook label.
+        If you are not using the latest version, make sure that the report has not already been [resolved](https://github.com/Divine-Journey-2/Divine-Journey-2/commits/main/).
   - type: input
     id: modpack-version
     attributes:
       label: Modpack version
       description: If you are not using the latest version, make sure that the request has not already been fulfilled.
       placeholder: "Example: 2.X.X"
+    validations:
+      required: true
+  - type: dropdown
+    id: language
+    attributes:
+      label: What language does it occur in?
+      description: If there is no localization done, select Unlocalized. Otherwise, select the relevant language.
+      options:
+        - American English (default)
+        - Chinese
+        - Unlocalized
     validations:
       required: true
   - type: textarea
@@ -33,4 +48,8 @@ body:
     attributes:
       label: Your Divine Journey 2 Discord Username
       description: If you haven't joined the Discord, this will make it harder to contact you if we need additional info.
-      placeholder: "Example: Dyno#3861"
+      placeholder: "Example: atricos, waitingidly"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make this typo report!

--- a/.github/ISSUE_TEMPLATE/003-balance-request.yml
+++ b/.github/ISSUE_TEMPLATE/003-balance-request.yml
@@ -1,25 +1,27 @@
-name: Feature request
-description: Suggest something that should be added.
-labels: ["Feature Request"]
+name: Balance Request
+description: Requesting something because something's too easy / difficult to craft, easy / difficult to fight against, etc.
+labels: ["Balance Request"]
+type: Task
 body:
   - type: markdown
     attributes:
       value: |
         Before submitting an issue, check if your request has been submitted before. If it has, please don't submit a duplicate.
-        If you are not using the latest version, make sure that the request has not already been fulfilled.
+        Please be aware that significant changes, such as altering the progression of mods, are unlikely to be considered.
+        If you are not using the latest version, make sure that the request has not already been [fulfilled](https://github.com/Divine-Journey-2/Divine-Journey-2/commits/main/).
   - type: textarea
-    id: feature-description
+    id: request-description
     attributes:
-      label: Describe the feature
-      description: Describe the feature you are requesting in a clear and concise way.
-      placeholder: "Example: I would like to see ... in the modpack. / ... should be enabled. / A new ... could be added."
+      label: Describe the request
+      description: A clear and concise description of what the request is.
+      placeholder: "Example: I think ... is too expensive/grindy ..., the recipe should instead be ..."
     validations:
       required: true
   - type: textarea
-    id: reason
+    id: change-reason
     attributes:
-      label: Reasons why this should be added
-      description: Sensible points on why the modpack would be "better" if this was added.
+      label: Reasons why this should be changed
+      description: Sensible points on why the modpack would be "better" if this was changed.
       placeholder: "Example: The automation setup comes too late ... / There is nothing to do in the meantime ..."
     validations:
       required: true
@@ -44,4 +46,8 @@ body:
     attributes:
       label: Your Divine Journey 2 Discord Username
       description: If you haven't joined the Discord, this will make it harder to contact you if we need additional info.
-      placeholder: "Example: Dyno#3861"
+      placeholder: "Example: atricos, waitingidly"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make this balance request!

--- a/.github/ISSUE_TEMPLATE/004-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/004-feature-request.yml
@@ -1,27 +1,26 @@
-name: Balance request
-description: Requesting something because something's too easy / difficult to craft, easy
-  / difficult to fight against, etc.
-labels: ["Balance Request"]
+name: Feature Request
+description: Suggest something that should be added.
+labels: ["Feature Request"]
+type: Feature
 body:
   - type: markdown
     attributes:
       value: |
         Before submitting an issue, check if your request has been submitted before. If it has, please don't submit a duplicate.
-        Please be aware that significant changes, such as altering the progression of mods, are unlikely to be considered.
-        If you are not using the latest version, make sure that the request has not already been fulfilled.
+        If you are not using the latest version, make sure that the request has not already been [fulfilled](https://github.com/Divine-Journey-2/Divine-Journey-2/commits/main/).
   - type: textarea
-    id: request-description
+    id: feature-description
     attributes:
-      label: Describe the request
-      description: A clear and concise description of what the request is.
-      placeholder: "Example: I think ... is too expensive/grindy ..., the recipe should instead be ..."
+      label: Describe the feature
+      description: Describe the feature you are requesting in a clear and concise way.
+      placeholder: "Example: I would like to see ... in the modpack. / ... should be enabled. / A new ... could be added."
     validations:
       required: true
   - type: textarea
-    id: change-reason
+    id: reason
     attributes:
-      label: Reasons why this should be changed
-      description: Sensible points on why the modpack would be "better" if this was changed.
+      label: Reasons why this should be added
+      description: Sensible points on why the modpack would be "better" if this was added.
       placeholder: "Example: The automation setup comes too late ... / There is nothing to do in the meantime ..."
     validations:
       required: true
@@ -46,4 +45,8 @@ body:
     attributes:
       label: Your Divine Journey 2 Discord Username
       description: If you haven't joined the Discord, this will make it harder to contact you if we need additional info.
-      placeholder: "Example: Dyno#3861"
+      placeholder: "Example: atricos, waitingidly"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make this feature request!

--- a/.github/ISSUE_TEMPLATE/005-mod-request.yml
+++ b/.github/ISSUE_TEMPLATE/005-mod-request.yml
@@ -1,17 +1,26 @@
-name: Mod request
+name: Mod Request
 description: Suggest a mod to be added to the pack.
 labels: ["Feature Request", "Mod Request"]
+type: Feature
 body:
   - type: markdown
     attributes:
       value: |
         Before submitting an issue, check if your request has been submitted before. If it has, please don't submit a duplicate.
         Please be aware that new mods are unlikely to be added, given the effort required to balance and integrate them. Remember that you are free to add any mod to your personal version of the pack.
+        If you are not using the latest version, make sure that the request has not already been [fulfilled](https://github.com/Divine-Journey-2/Divine-Journey-2/commits/main/).
   - type: input
     id: mod-name
     attributes:
       label: Mod Name
-      description: Provide the name of the mod, and link its Curseforge page. If it does not have a Curseforge page and is not on the Curseforge approved 3rd party mods list, the mod cannot be added.
+      description: Provide the name of the mod
+    validations:
+      required: true
+  - type: input
+    id: mod-link
+    attributes:
+      label: CurseForge Link
+      description: Provide a link to its CurseForge page. If it does not have a CurseForge page and is not on the CurseForge approved 3rd party mods list, the mod cannot be added.
     validations:
       required: true
   - type: textarea
@@ -34,4 +43,8 @@ body:
     attributes:
       label: Your Divine Journey 2 Discord Username
       description: If you haven't joined the Discord, this will make it harder to contact you if we need additional info.
-      placeholder: "Example: Dyno#3861"
+      placeholder: "Example: atricos, waitingidly"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to make this mod request!

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,10 +101,10 @@ jobs:
         run: |
           echo "[Changelog](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/changelog/LATEST.md)" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.build.outputs.client_name }}" != '' ]; then
-            echo "Uploaded the client zip file with the name ${{ steps.build.outputs.client_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "Uploaded the client zip file with the name `${{ steps.build.outputs.client_name }}.zip`" >> $GITHUB_STEP_SUMMARY
           fi
           if [ "${{ steps.build.outputs.server_name }}" != '' ]; then
-            echo "Uploaded the server zip file with the name ${{ steps.build.outputs.server_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "Uploaded the server zip file with the name `${{ steps.build.outputs.server_name }}.zip`" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Download via [Nightly](https://nightly.link/${{ github.repository }}/workflows/nightly/main)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,10 +173,10 @@ jobs:
         run: |
           echo "[Changelog](https://github.com/${{ github.repository }}/blob/${{ inputs.version }}/changelog/Divine_Journey_${{ inputs.version }}.md)" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.build.outputs.client_name }}" != '' ]; then
-            echo "Uploaded the client zip file with the name ${{ steps.build.outputs.client_name }}.zip" >> $GITHUB_STEP_SUMMARY
+            echo "Uploaded the client zip file with the name `${{ steps.build.outputs.client_name }}.zip`" >> $GITHUB_STEP_SUMMARY
           fi
           if [ "${{ steps.build.outputs.server_name }}" != '' ]; then
-            echo "Uploaded the server zip file with the name ${{ steps.build.outputs.server_name }}.zip" >> $GITHUB_STEP_SUMMARY
+            echo "Uploaded the server zip file with the name `${{ steps.build.outputs.server_name }}.zip`" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "-----" >> $GITHUB_STEP_SUMMARY

--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -21,5 +21,6 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 ## GitHub Developments:
 
+- Update Issue Templates to use types, fix issues, and order in a more valuable way.
 
 ## Miscellaneous Changes:


### PR DESCRIPTION
changes in this PR:
- recently, issues added a new "type" parameter. ive been adding it manually so far (and went through and applied it to our open issues), this adds it automatically.
- update the templates to fix capitalization and typo issues, update the discord id, etc.
- rename templates so they are ordered in a sensible way to their actual contents instead of alphabetically.
- add `.zip` to the list of outputs of the nightly action.
- an everflowing spring of optimism that perhaps this time github yamls will work correctly the first time