### PR TITLE
fix: incorrect variable name for loop in autolaunch.bat

### DIFF
--- a/serverfiles/autolaunch.bat
+++ b/serverfiles/autolaunch.bat
@@ -28,7 +28,7 @@ timeout /t 3
 echo.
 echo Starting autorelaunch process.
 echo.
-:loop
+:server_loop
 %JAVA_VERSION% -server -Xms%MIN_RAM% -Xmx%MAX_RAM% %JAVA_PARAMETERS% -jar %FORGE_JAR% nogui
 
 echo.


### PR DESCRIPTION
This pull request makes a small change to the `serverfiles/autolaunch.bat` file, renaming the `:loop` label to `:server_loop` for proper functionality.