### PR TITLE
Amend manifest and buildscript

### DIFF
--- a/buildtools/build.py
+++ b/buildtools/build.py
@@ -19,6 +19,7 @@ from threading import Thread
 import json
 import os
 import shutil
+import urllib
 import subprocess
 import requests
 from requests.adapters import HTTPAdapter
@@ -262,6 +263,7 @@ def downloadMod(downloadedMods: list, location: str, mod, retries: int):
     response = access.get(mod)
 
     link = mod.split("/")[-1]
+    link = urllib.parse.unquote(link)
     with open(f"{cache}/mods/{location}/{link}", "w+b") as jar:
         jar.write(response.content)
         print(f"{mod} downloaded")
@@ -312,7 +314,7 @@ def getGitTagVersion() -> str:
 def getStandardName(name: str, version: str) -> str:
     """Get the standard name based on the args"""
     name = name.replace(' ', '_')
-    version = version.replace('2.', '.')
+    version = version.replace('2.', '.', 1)
     return f"{name}{version}"
 
 

--- a/buildtools/update_version.py
+++ b/buildtools/update_version.py
@@ -9,8 +9,7 @@ Presumes that the old version is exactly equal to the tag used
 """
 
 from argparse import ArgumentParser
-from subprocess import run
-from os import getenv, path
+from os import getenv
 from shutil import copyfile
 from collections import OrderedDict
 
@@ -23,11 +22,6 @@ def parse_args():
                         help="the version being updated to")
     return parser.parse_args()
 
-
-basePath = path.normpath(path.abspath(f"{__file__}/../../"))
-UPDATE_QUESTBOOK = f"""YOU'LL NEED TO UPDATE YOUR QUEST BOOK BY TYPING:
-/bq_admin default load
-(This has to only be done once in multiplayer, by an admin.)\n"""
 
 def convertChangelog(version: str):
     """Converts and filters the existing changelog in the LATEST.md file to a file named after the version"""

--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -7,7 +7,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 - Add Morph Overlay 1.0.1
 - Add Crash Assistant 1.10.20
 - Add Botania CEU 369b
-- Add Red Core 0.7-Dev-1
+- Add Red Core 0.6
 - Add Alfheim 1.6
 - Add NoiseThreader 1.1.1
 - Add Integrated Derivitive 1.1.2
@@ -70,6 +70,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 - Fix Integrated Dynamics Delayer being formatted incorrectly and missing data (Integrated Derivative).
 - Fix the wrong type of Charcoal Block being used in AbyssalCraft.
 - Fix scrolling before changing GUIs treating the item behind hovered afterwards as just been scrolled (Mouse Tweaks Unofficial).
+- Fix mixins loading vanilla classes sometimes breaking the FML deobfuscation process.
 
 ## Balance Adjustments:
 
@@ -149,6 +150,8 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 
 - Fix error in `questbook.py` by attempting to use a backslash in a comment.
 - Adjust `questbook.py` to allow prefixes of a length other than 3 characters.
+- Make the server zip contain files with parsed names.
+- Fix a bug where the release number would be incorrect if ending with a 2.
 
 ## Miscellaneous Changes:
 

--- a/manifest.json
+++ b/manifest.json
@@ -507,12 +507,6 @@
       "required": true
     },
     {
-      "slug": "quark",
-      "projectID": 243121,
-      "fileID": 2924091,
-      "required": true
-    },
-    {
       "slug": "more-overlays",
       "projectID": 243478,
       "fileID": 2745657,
@@ -1234,6 +1228,12 @@
       "required": true
     },
     {
+      "slug": "quark-rotn-edition",
+      "projectID": 417392,
+      "fileID": 7215216,
+      "required": true
+    },
+    {
       "slug": "tinkers-aether-dman-edition",
       "projectID": 419003,
       "fileID": 3215120,
@@ -1414,7 +1414,8 @@
       "slug": "crash-assistant",
       "projectID": 1154099,
       "fileID": 7215788,
-      "required": true
+      "required": true,
+      "clientOnly": true
     },
     {
       "slug": "botania-ceu",

--- a/overrides/config/crash_assistant/modlist.json
+++ b/overrides/config/crash_assistant/modlist.json
@@ -19,10 +19,10 @@
     "modId": "mixinbooter",
     "version": "10.7"
   },
-  "!Red-Core-MC-1.8-1.12-0.7-Dev-1.jar": {
-    "jarName": "!Red-Core-MC-1.8-1.12-0.7-Dev-1.jar",
+  "!Red-Core-MC-1.8-1.12-0.6.jar": {
+    "jarName": "!Red-Core-MC-1.8-1.12-0.6.jar",
     "modId": "redcore",
-    "version": "0.7-Dev-1"
+    "version": "0.6"
   },
   "`FermiumBooter-1.1.1.jar": {
     "jarName": "`FermiumBooter-1.1.1.jar",

--- a/overrides/config/normalasm.cfg
+++ b/overrides/config/normalasm.cfg
@@ -305,7 +305,7 @@ modfixes {
 
 remapper {
     # Optimizing Forge's Remapper for not storing redundant entries - <default: true>
-    B:optimizeFMLRemapper=true
+    B:optimizeFMLRemapper=false
 }
 
 


### PR DESCRIPTION
changes in this PR:
- fix discrepancy between `Red Core 0.7-Dev-1` and it actually being `Red Core 0.6`.
- fix not quark rotn not being in manifest.
- the server zip not having the correct names for some mods, potentially leading to duplicate mods in some server packs.
- a startup crash where the FML deobfuscation failed.