### PR TITLE
Add Second Blood Magic MLF Recipe

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -17,6 +17,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 ## Balance Adjustments:
 
 - Reduce the size the Germination Ritual checks for crops from 39^3 to 11^3.
+- Add a second Blood Magic Mob Loot Fabricator recipe with increased LE generation
 
 ## QoL Improvements:
 

--- a/overrides/config/modularmachinery/recipes/mob_loot_fabricator_blood_magic_2.json
+++ b/overrides/config/modularmachinery/recipes/mob_loot_fabricator_blood_magic_2.json
@@ -1,0 +1,71 @@
+{
+    "machine": "mob_loot_fabricator",
+    "registryName": "mob_loot_fabricator_blood_magic_2",
+    "recipeTime": 20,
+    "requirements": [
+        {
+            "type": "item",
+            "io-type": "input",
+            "item": "bhc:blue_heart_canister",
+            "amount": 1,
+            "chance": 0
+        },
+        {
+            "type": "lifeessence",
+            "io-type": "input",
+            "essenceamount": 500
+        },
+        {
+            "type": "lifeessence",
+            "io-type": "output",
+            "essenceamount": 25000
+        },
+        {
+            "type": "will",
+            "io-type": "output",
+            "willtype": "raw",
+            "willamount": 100,
+            "min": 0
+        },
+        {
+            "type": "will",
+            "io-type": "output",
+            "willtype": "corrosive",
+            "willamount": 100,
+            "min": 0
+        },
+        {
+            "type": "will",
+            "io-type": "output",
+            "willtype": "destructive",
+            "willamount": 100,
+            "min": 0
+        },
+        {
+            "type": "will",
+            "io-type": "output",
+            "willtype": "vengeful",
+            "willamount": 100,
+            "min": 0
+        },
+        {
+            "type": "will",
+            "io-type": "output",
+            "willtype": "steadfast",
+            "willamount": 100,
+            "min": 0
+        },
+        {
+            "type": "fluid",
+            "io-type": "output",
+            "fluid": "lifeessence",
+            "amount": 16000
+        },
+        {
+            "type": "item",
+            "io-type": "output",
+            "item": "bloodmagic:blood_shard@0",
+            "amount": 1
+        }
+    ]
+}


### PR DESCRIPTION
What is added:
Adds a second Blood Magic Mob Loot Fabricator recipe that produces the same things as the original one but instead produces 25,000 LE sent to the orb and 16,000 LE sent to the fluid output hatch. The catalyst item is the blue heart canister. 

Reason:
Should be added to reduce MLF spam which is needed to replace the Well of Suffering entirely. This also adds a reason to doing the blue heart canister recipe beyond just +1 hp which doesn't do much at Ch 23.