### PR TITLE
Add Upgrade to the Chemical Caster

### DIFF
--- a/changelog/LATEST.md
+++ b/changelog/LATEST.md
@@ -17,6 +17,7 @@ View all [changelogs](https://github.com/Divine-Journey-2/Divine-Journey-2/tree/
 ## Balance Adjustments:
 
 - Reduce the size the Germination Ritual checks for crops from 39^3 to 11^3.
+- Add upgrade to the Chemical Caster multiblock using Celestial Crystal Cores instead of the Crystal Cores for 10x recipe speeds.
 
 ## QoL Improvements:
 

--- a/overrides/config/modularmachinery/machinery/chemical_caster.json
+++ b/overrides/config/modularmachinery/machinery/chemical_caster.json
@@ -3,6 +3,29 @@
     "localizedname": "Chemical Caster",
     "requires-blueprint": true,
     "color": "3D3D3D",
+    "modifiers": [
+        {
+            "description": "Celestial Crystal Cores instead of the Crystal Cores for 10x recipe speeds.",
+            "elements": "contenttweaker:celestial_crystal_core",
+            "x": 0,
+            "y": [1, 3],
+            "z": 2,
+            "modifiers": [
+                {
+                    "io": "input",
+                    "target": "duration",
+                    "operation": 1,
+                    "multiplier": 0.1
+                },
+                {
+                    "io": "input",
+                    "target": "energy",
+                    "operation": 1,
+                    "multiplier": 0.1
+                }
+            ]
+        }
+    ],
     "parts": [
         {
             "x": -2,


### PR DESCRIPTION
What is added:
Adds an upgrade to the Chemical Caster using Celestial Crystal Cores instead of the Crystal Cores for 10x recipe speeds.

Reason:
Because the Chemical Caster multiblock can't be tick accelerated, Chemical Combiners are faster than the multiblock despite posing as a superior option for creating ingots. Celestial Crystal Cores as the upgrade make thematical sense and are reasonable progression wise.